### PR TITLE
Revert "ksmbd-tools: disable tbuf and rbuf caching by default"

### DIFF
--- a/lib/config_parser.c
+++ b/lib/config_parser.c
@@ -668,6 +668,12 @@ static void fixup_missing_global_group(void)
 		       ret);
 }
 
+static void default_global_group(void)
+{
+	global_conf.flags |= KSMBD_GLOBAL_FLAG_CACHE_TBUF;
+	global_conf.flags |= KSMBD_GLOBAL_FLAG_CACHE_RBUF;
+}
+
 static void global_group(struct smbconf_group *group)
 {
 	list_foreach(&group->kv, global_group_kv, NULL);
@@ -715,6 +721,8 @@ out:
 static int __cp_parse_smbconfig(const char *smbconf, long flags)
 {
 	int ret;
+
+	default_global_group();
 
 	ret = cp_smbconfig_hash_create(smbconf);
 	if (ret)


### PR DESCRIPTION
This reverts commit 9f4f84f5ee4b115ba3235149c1bac8e24c9ec490.