### PR TITLE
ksmbd-tools: reorganize ndr write string functions

### DIFF
--- a/include/rpc.h
+++ b/include/rpc.h
@@ -314,8 +314,9 @@ __u32 ndr_read_union_int32(struct ksmbd_dcerpc *dce);
 
 int ndr_write_bytes(struct ksmbd_dcerpc *dce, void *value, size_t sz);
 int ndr_read_bytes(struct ksmbd_dcerpc *dce, void *value, size_t sz);
-int ndr_write_vstring(struct ksmbd_dcerpc *dce, void *value,
-		size_t max_len, size_t actual_len);
+int ndr_write_vstring(struct ksmbd_dcerpc *dce, void *value);
+int ndr_write_string(struct ksmbd_dcerpc *dce, char *str);
+int ndr_write_lsa_string(struct ksmbd_dcerpc *dce, char *str);
 char *ndr_read_vstring(struct ksmbd_dcerpc *dce);
 void ndr_read_vstring_ptr(struct ksmbd_dcerpc *dce, struct ndr_char_ptr *ctr);
 void ndr_read_uniq_vsting_ptr(struct ksmbd_dcerpc *dce,

--- a/mountd/rpc.c
+++ b/mountd/rpc.c
@@ -384,21 +384,12 @@ int ndr_read_bytes(struct ksmbd_dcerpc *dce, void *value, size_t sz)
 	return 0;
 }
 
-int ndr_write_vstring(struct ksmbd_dcerpc *dce, void *value,
-		size_t max_len, size_t actual_len)
+static gchar *ndr_convert_char_to_unicode(struct ksmbd_dcerpc *dce, char *str,
+		size_t len, gsize *bytes_written)
 {
 	gchar *out;
 	gsize bytes_read = 0;
-	gsize bytes_written = 0;
-
-	char *raw_value = value;
 	int charset = KSMBD_CHARSET_UTF16LE;
-	int ret;
-
-	if (!value) {
-		raw_value = "";
-		max_len = actual_len = strlen("") + 1;
-	}
 
 	if (!(dce->flags & KSMBD_DCERPC_LITTLE_ENDIAN))
 		charset = KSMBD_CHARSET_UTF16BE;
@@ -406,12 +397,31 @@ int ndr_write_vstring(struct ksmbd_dcerpc *dce, void *value,
 	if (dce->flags & KSMBD_DCERPC_ASCII_STRING)
 		charset = KSMBD_CHARSET_UTF8;
 
-	out = ksmbd_gconvert(raw_value,
-			     actual_len,
+	out = ksmbd_gconvert(str,
+			     len,
 			     charset,
 			     KSMBD_CHARSET_DEFAULT,
 			     &bytes_read,
-			     &bytes_written);
+			     bytes_written);
+
+	return out;
+}
+
+int ndr_write_vstring(struct ksmbd_dcerpc *dce, void *value)
+{
+	gchar *out;
+	gsize bytes_written = 0;
+
+	size_t raw_len;
+	char *raw_value = value;
+	int ret;
+
+	if (!value)
+		raw_value = "";
+
+	raw_len = strlen(raw_value) + 1;
+	out = ndr_convert_char_to_unicode(dce, raw_value, raw_len,
+			&bytes_written);
 	if (!out)
 		return -EINVAL;
 
@@ -425,9 +435,61 @@ int ndr_write_vstring(struct ksmbd_dcerpc *dce, void *value,
 	 * The third integer gives the actual number of elements being
 	 * passed, including the terminator.
 	 */
-	ret = ndr_write_int32(dce, max_len);
+	ret = ndr_write_int32(dce, raw_len);
 	ret |= ndr_write_int32(dce, 0);
-	ret |= ndr_write_int32(dce, actual_len);
+	ret |= ndr_write_int32(dce, raw_len);
+	ret |= ndr_write_bytes(dce, out, bytes_written);
+	auto_align_offset(dce);
+
+	g_free(out);
+	return ret;
+}
+
+int ndr_write_string(struct ksmbd_dcerpc *dce, char *str)
+{
+	gchar *out;
+	gsize bytes_written = 0;
+
+	size_t len;
+	int ret;
+
+	if (!str)
+		str = "";
+
+	len = strlen(str);
+	out = ndr_convert_char_to_unicode(dce, str, len, &bytes_written);
+	if (!out)
+		return -EINVAL;
+
+	ret = ndr_write_int32(dce, len); // max count
+	ret |= ndr_write_int32(dce, 0);
+	ret |= ndr_write_int32(dce, len); // actual count
+	ret |= ndr_write_bytes(dce, out, bytes_written);
+	auto_align_offset(dce);
+
+	g_free(out);
+	return ret;
+}
+
+int ndr_write_lsa_string(struct ksmbd_dcerpc *dce, char *str)
+{
+	gchar *out;
+	gsize bytes_written = 0;
+
+	size_t len;
+	int ret;
+
+	if (!str)
+		str = "";
+
+	len = strlen(str);
+	out = ndr_convert_char_to_unicode(dce, str, len, &bytes_written);
+	if (!out)
+		return -EINVAL;
+
+	ret = ndr_write_int32(dce, len + 1); // max count
+	ret |= ndr_write_int32(dce, 0);
+	ret |= ndr_write_int32(dce, len); // actual count
 	ret |= ndr_write_bytes(dce, out, bytes_written);
 	auto_align_offset(dce);
 

--- a/mountd/rpc_samr.c
+++ b/mountd/rpc_samr.c
@@ -143,11 +143,9 @@ int samr_ndr_write_domain_array(struct ksmbd_rpc_pipe *pipe)
 
 	for (i = 0; i < num_domain_entries; i++) {
 		gpointer entry;
-		size_t name_len;
 
 		entry = g_array_index(domain_entries,  gpointer, i);
-		name_len = strlen((char *)entry);
-		ret |= ndr_write_vstring(dce, (char *)entry, name_len, name_len);
+		ret |= ndr_write_string(dce, (char *)entry);
 	}
 
 	return ret;
@@ -341,7 +339,6 @@ static int samr_query_user_info_return(struct ksmbd_rpc_pipe *pipe)
 	char *home_dir, *profile_path;
 	char hostname[NAME_MAX];
 	int home_dir_len, i;
-	size_t len;
 
 	ch = samr_ch_lookup(dce->sm_req.handle);
 	if (!ch)
@@ -451,11 +448,9 @@ static int samr_query_user_info_return(struct ksmbd_rpc_pipe *pipe)
 	ndr_write_int8(dce, 0);
 	ndr_write_int8(dce, 0);
 
-	len = strlen(ch->user->name);
-	ndr_write_vstring(dce, ch->user->name, len, len);
-	ndr_write_vstring(dce, ch->user->name, len, len);
-	len = strlen(home_dir);
-	ndr_write_vstring(dce, home_dir, len, len);
+	ndr_write_string(dce, ch->user->name);
+	ndr_write_string(dce, ch->user->name);
+	ndr_write_string(dce, home_dir);
 
 	/* Home Drive, Logon Script */
 	for (i = 0; i < 2; i++) {
@@ -464,8 +459,7 @@ static int samr_query_user_info_return(struct ksmbd_rpc_pipe *pipe)
 		ndr_write_int32(dce, 0);
 	}
 
-	len = strlen(profile_path);
-	ndr_write_vstring(dce, profile_path, len, len);
+	ndr_write_string(dce, profile_path);
 
 	/* Description, Workstations, Comments, Parameters */
 	for (i = 0; i < 4; i++) {

--- a/mountd/rpc_srvsvc.c
+++ b/mountd/rpc_srvsvc.c
@@ -93,22 +93,17 @@ static int __share_entry_rep_ctr1(struct ksmbd_dcerpc *dce, gpointer entry)
 static int __share_entry_data_ctr0(struct ksmbd_dcerpc *dce, gpointer entry)
 {
 	struct ksmbd_share *share = entry;
-	size_t len;
 
-	len = strlen(share->name) + 1;
-	return ndr_write_vstring(dce, share->name, len, len);
+	return ndr_write_vstring(dce, share->name);
 }
 
 static int __share_entry_data_ctr1(struct ksmbd_dcerpc *dce, gpointer entry)
 {
 	struct ksmbd_share *share = entry;
 	int ret;
-	size_t len;
 
-	len = strlen(share->name) + 1;
-	ret = ndr_write_vstring(dce, share->name, len, len);
-	len = strlen(share->comment) + 1;
-	ret |= ndr_write_vstring(dce, share->comment, len, len);
+	ret = ndr_write_vstring(dce, share->name);
+	ret |= ndr_write_vstring(dce, share->comment);
 	return ret;
 }
 

--- a/mountd/rpc_wkssvc.c
+++ b/mountd/rpc_wkssvc.c
@@ -61,15 +61,12 @@ static int __netwksta_entry_data_ctr100(struct ksmbd_dcerpc *dce,
 					gpointer entry)
 {
 	int ret = 0;
-	size_t len;
 
 	/*
 	 * Umm... Hmm... Huh...
 	 */
-	len = strlen(STR_VAL(dce->wi_req.server_name)) + 1;
-	ret |= ndr_write_vstring(dce, STR_VAL(dce->wi_req.server_name), len, len);
-	len = strlen(global_conf.work_group) + 1;
-	ret |= ndr_write_vstring(dce, global_conf.work_group, len, len);
+	ret |= ndr_write_vstring(dce, STR_VAL(dce->wi_req.server_name));
+	ret |= ndr_write_vstring(dce, global_conf.work_group);
 	return ret;
 }
 


### PR DESCRIPTION
Instead of adding max_len and actual_len arguments in
ndr_write_vstring(), declare ndr_write_lsa_string_large() and
ndr_write_string().

Cc: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>
Cc: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>