### PR TITLE
ksmbd-tools: fix memleak in usm_add_subauth_global_conf()

### DIFF
--- a/lib/management/user.c
+++ b/lib/management/user.c
@@ -246,7 +246,7 @@ int usm_add_subauth_global_conf(char *data)
 	}
 
 	*spos = 0x00;
-	global_conf.gen_subauth[0] = atoi(g_strdup(pos));
+	global_conf.gen_subauth[0] = atoi(pos);
 	pos = spos + 1;
 
 	spos = strchr(pos, ':');
@@ -255,8 +255,8 @@ int usm_add_subauth_global_conf(char *data)
 		return -EINVAL;
 	}
 	*spos = 0x00;
-	global_conf.gen_subauth[1] = atoi(g_strdup(pos));
-	global_conf.gen_subauth[2] = atoi(g_strdup(spos + 1));
+	global_conf.gen_subauth[1] = atoi(pos);
+	global_conf.gen_subauth[2] = atoi(spos + 1);
 
 	return 0;
 }


### PR DESCRIPTION
Remove unneeded g_strdup() in usm_add_subauth_global_conf().

Signed-off-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>
Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>