### PR TITLE
ksmbd-tools: release 3.3.4 version

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define KSMBD_TOOLS_VERSION "3.3.3"
+#define KSMBD_TOOLS_VERSION "3.3.4"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
Major changes are:
 - add "vfs objects = acl_xattr" parameter in configuration.
 - fix wrong group domain name in lsarpc response.
 - set to SID_TYPE_UNKNOWN if there is no domain sid in server.

Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>