### PR TITLE
ksmbd-tools: release 3.3.8 version

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define KSMBD_TOOLS_VERSION "3.3.7"
+#define KSMBD_TOOLS_VERSION "3.3.8"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
Major changes are:
 - disable symlink by default.
 - remove smack inherit leftovers.
 - Enable guest access on IPC$ share by default.

Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>