### PR TITLE
ksmbd-tools: Only parse ksmbd.subauth if it exists

### DIFF
--- a/mountd/mountd.c
+++ b/mountd/mountd.c
@@ -167,14 +167,17 @@ static int create_subauth_file(char *path_subauth)
 
 static int generate_sub_auth(void)
 {
-	int rc;
+	int rc = -EINVAL;
 	char *path_subauth;
 
 	path_subauth = make_path_subauth();
 	if (!path_subauth)
 		return -ENOMEM;
 retry:
-	rc = cp_parse_subauth(path_subauth);
+	if (g_file_test(path_subauth, G_FILE_TEST_EXISTS)) {
+		rc = cp_parse_subauth(path_subauth);
+	}
+
 	if (rc < 0) {
 		rc = create_subauth_file(path_subauth);
 		if (rc)


### PR DESCRIPTION
Attempting to parse ksmbd.subauth without it existing causes
an error. Starting up from scratch without ksmbd.subauth should not
cause an error. A corrupt ksmbd.subauth should however cause an error.