### PR TITLE
ksmbd-tools: fix memory leak in rpc

### DIFF
--- a/mountd/rpc.c
+++ b/mountd/rpc.c
@@ -417,7 +417,7 @@ int ndr_write_vstring(struct ksmbd_dcerpc *dce, void *value)
 	if (!value)
 		raw_value = "";
 
-	raw_len = strlen(raw_value) + 1;
+	raw_len = strlen(raw_value);
 	out = ndr_convert_char_to_unicode(dce, raw_value, raw_len,
 			&bytes_written);
 	if (!out)


### PR DESCRIPTION
Steps to reproduce:
 * map network drive from Windows
 * select file->properties
 * observe ksmbd.mountd process growing

Signed-off-by: Abylay Ospan <aospan@netup.ru>