### PR TITLE
ksmbd-tools: fix unit file

### DIFF
--- a/ksmbd.service
+++ b/ksmbd.service
@@ -10,7 +10,7 @@ Group=root
 RemainAfterExit=yes
 ExecStartPre=-/sbin/modprobe ksmbd
 ExecStart=/sbin/ksmbd.mountd -s
-ExecReload=/sbin/ksmbd.control -s && /sbin/ksmbd.mountd
+ExecReload=/bin/sh -c '/sbin/ksmbd.control -s && /sbin/ksmbd.mountd -s'
 ExecStop=/sbin/ksmbd.control -s
 
 [Install]


### PR DESCRIPTION
Shell logic must be enclosed in shell subprocess, systemd cannot handle it directly, so reload will fail.