### PR TITLE
ksmbd-tools: perform a build test with make distcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
  - email: true
 
 before_install:
- - sudo apt-get install libnl-3-dev libnl-genl-3-dev
+ - sudo apt-get install libnl-3-dev libnl-genl-3-dev libkrb5-dev
  - gcc --version
  - g++ --version
 
@@ -14,4 +14,4 @@ script:
  # Compilation
  - ./autogen.sh
  - ./configure
- - make
+ - make DISTCHECK_CONFIGURE_FLAGS=--enable-krb5 distcheck


### PR DESCRIPTION
Perform a build test with make distcheck, and
set the --enable-krb5 configuration.

Signed-off-by: Hyunchul Lee <hyc.lee@gmail.com>