### PR TITLE
ksmbd-tools: Add support for Heimdal as the Kerberos 5 implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,7 @@ AC_ARG_ENABLE(krb5,
 
 # Checks for header files.
 if test "$enable_krb5" != "no"; then
+	CPPFLAGS="$CPPFLAGS $LIBKRB5_CFLAGS"
 	AC_CHECK_HEADERS([krb5.h])
 	if test x$ac_cv_header_krb5_h != xyes; then
 		if test "$enable_krb5" = "yes"; then
@@ -56,6 +57,32 @@ AS_IF([test "$has_libnl_ver" -eq 0], [
 if test "$enable_krb5" != "no"; then
 	PKG_CHECK_MODULES([LIBKRB5], [krb5])
 	AC_DEFINE([CONFIG_KRB5], [], "support kerberos authentication")
+	ksmbd_tools_LIBS=$LIBS
+	LIBS="$LIBS $LIBKRB5_LIBS"
+	AC_CHECK_FUNCS([krb5_auth_con_getrecvsubkey])
+	LIBS=$ksmbd_tools_LIBS
+	AC_CACHE_CHECK([for keyvalue in krb5_keyblock], [ac_cv_have_krb5_keyblock_keyvalue], [
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <krb5.h>], [krb5_keyblock key; key.keyvalue.data = NULL;])],
+			[ac_cv_have_krb5_keyblock_keyvalue="yes"], [ac_cv_have_krb5_keyblock_keyvalue="no"])
+	])
+	if test "$ac_cv_have_krb5_keyblock_keyvalue" = "yes" ; then
+		AC_DEFINE(HAVE_KRB5_KEYBLOCK_KEYVALUE, [], "the krb5_keyblock struct has a keyvalue property")
+	fi
+	AC_CACHE_CHECK([for double pointer in krb5_auth_con_getauthenticator], [ac_cv_have_krb5_auth_con_getauthenticator_double_pointer], [
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <krb5.h>
+				krb5_error_code krb5_auth_con_getauthenticator(krb5_context, krb5_auth_context, krb5_authenticator**);], [])],
+			[ac_cv_have_krb5_auth_con_getauthenticator_double_pointer="yes"], [ac_cv_have_krb5_auth_con_getauthenticator_double_pointer="no"])
+	])
+	if test "$ac_cv_have_krb5_auth_con_getauthenticator_double_pointer" = "yes" ; then
+		AC_DEFINE(HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER, [], "the krb5_auth_con_getauthenticator function takes a double pointer")
+	fi
+	AC_CACHE_CHECK([for client in krb5_authenticator], [ac_cv_have_krb5_authenticator_client], [
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <krb5.h>], [krb5_authenticator authenti; authenti.client = NULL;])],
+			[ac_cv_have_krb5_authenticator_client="yes"], [ac_cv_have_krb5_authenticator_client="no"])
+	])
+	if test "$ac_cv_have_krb5_authenticator_client" = "yes" ; then
+		AC_DEFINE(HAVE_KRB5_AUTHENTICATOR_CLIENT, [], "the krb5_authenticator struct has a client property")
+	fi
 fi
 AM_CONDITIONAL(HAVE_LIBKRB5, [test "$enable_krb5" != "no"])
 

--- a/lib/management/spnego_krb5.c
+++ b/lib/management/spnego_krb5.c
@@ -19,6 +19,24 @@
 #include <asn1.h>
 #include "spnego_mech.h"
 
+#ifndef HAVE_KRB5_AUTH_CON_GETRECVSUBKEY
+krb5_error_code krb5_auth_con_getrecvsubkey(krb5_context context,
+			krb5_auth_context auth_context, krb5_keyblock **keyblock)
+{
+	return krb5_auth_con_getremotesubkey(context, auth_context, keyblock);
+}
+#endif /* HAVE_KRB5_AUTH_CON_GETRECVSUBKEY */
+
+#ifdef HAVE_KRB5_KEYBLOCK_KEYVALUE
+#define KRB5_KEY_TYPE(k)	((k)->keytype)
+#define KRB5_KEY_LENGTH(k)	((k)->keyvalue.length)
+#define KRB5_KEY_DATA(k)	((k)->keyvalue.data)
+#else
+#define KRB5_KEY_TYPE(k)	((k)->enctype)
+#define KRB5_KEY_LENGTH(k)	((k)->length)
+#define KRB5_KEY_DATA(k)	((k)->contents)
+#endif /* HAVE_KRB5_KEYBLOCK_KEYVALUE */
+
 struct spnego_krb5_ctx {
 	krb5_context	context;
 	krb5_keytab	keytab;
@@ -178,7 +196,12 @@ static int handle_krb5_authen(struct spnego_mech_ctx *mech_ctx,
 	krb5_data packet, ap_rep;
 	krb5_ticket *ticket = NULL;
 	krb5_keyblock *session_key;
+#ifdef HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER
 	krb5_authenticator *authenti;
+#else
+	krb5_authenticator authenti;
+#endif /* HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER */
+	krb5_principal client;
 	int retval = -EINVAL;
 	krb5_error_code krb_retval;
 
@@ -210,7 +233,7 @@ static int handle_krb5_authen(struct spnego_mech_ctx *mech_ctx,
 		return -EINVAL;
 	}
 
-	krb_retval = krb5_auth_con_getsendsubkey(krb5_ctx->context,
+	krb_retval = krb5_auth_con_getrecvsubkey(krb5_ctx->context,
 				auth_context, &session_key);
 	if (krb_retval) {
 		pr_krb5_err(krb5_ctx->context, krb_retval,
@@ -233,13 +256,31 @@ static int handle_krb5_authen(struct spnego_mech_ctx *mech_ctx,
 		goto out_free_rep;
 	}
 
+#ifndef HAVE_KRB5_AUTHENTICATOR_CLIENT
+	krb_retval = krb5_build_principal_ext(krb5_ctx->context, &client,
+			strlen(authenti->crealm), authenti->crealm, 0);
+	if (krb_retval) {
+		pr_krb5_err(krb5_ctx->context, krb_retval,
+				"while getting authenticator client\n");
+		goto out_free_auth;
+	}
+	krb_retval = copy_PrincipalName(&authenti->cname, &client->name);
+	if (krb_retval) {
+		pr_krb5_err(krb5_ctx->context, krb_retval,
+				"while copying authenticator client name\n");
+		goto out_free_client;
+	}
+#else
+	client = authenti->client;
+#endif /* HAVE_KRB5_AUTHENTICATOR_CLIENT */
+
 	krb_retval = krb5_unparse_name_flags(krb5_ctx->context,
-				authenti->client,
+				client,
 				KRB5_PRINCIPAL_UNPARSE_NO_REALM, &client_name);
 	if (krb_retval) {
 		pr_krb5_err(krb5_ctx->context, krb_retval,
 				"while unparsing client name\n");
-		goto out_free_auth;
+		goto out_free_client;
 	}
 
 	memset(auth_out, 0, sizeof(*auth_out));
@@ -247,32 +288,40 @@ static int handle_krb5_authen(struct spnego_mech_ctx *mech_ctx,
 	if (!auth_out->user_name) {
 		krb5_free_unparsed_name(krb5_ctx->context, client_name);
 		retval = -ENOMEM;
-		goto out_free_auth;
+		goto out_free_client;
 	}
 	krb5_free_unparsed_name(krb5_ctx->context, client_name);
 
-	auth_out->sess_key = malloc(session_key->length);
+	auth_out->sess_key = malloc(KRB5_KEY_LENGTH(session_key));
 	if (!auth_out->sess_key) {
 		free(auth_out->user_name);
 		retval = -ENOMEM;
-		goto out_free_auth;
+		goto out_free_client;
 	}
-	memcpy(auth_out->sess_key, session_key->contents, session_key->length);
-	auth_out->key_len = session_key->length;
+	memcpy(auth_out->sess_key, KRB5_KEY_DATA(session_key), KRB5_KEY_LENGTH(session_key));
+	auth_out->key_len = KRB5_KEY_LENGTH(session_key);
 
 	if (spnego_encode(ap_rep.data, ap_rep.length,
 			mech_ctx->oid, mech_ctx->oid_len,
 			&auth_out->spnego_blob, &auth_out->blob_len)) {
 		free(auth_out->user_name);
 		free(auth_out->sess_key);
-		goto out_free_auth;
+		goto out_free_client;
 	}
 
 	pr_info("Succeeded to authenticate %s\n", auth_out->user_name);
 	retval = 0;
 
+out_free_client:
+#ifndef HAVE_KRB5_AUTHENTICATOR_CLIENT
+	krb5_free_principal(krb5_ctx->context, client);
+#endif /* HAVE_KRB5_AUTHENTICATOR_CLIENT */
 out_free_auth:
+#ifdef HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER
 	krb5_free_authenticator(krb5_ctx->context, authenti);
+#else
+	krb5_free_authenticator(krb5_ctx->context, &authenti);
+#endif /* HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER */
 out_free_rep:
 	krb5_free_data_contents(krb5_ctx->context, &ap_rep);
 out_free_key:

--- a/mountd/Makefile.am
+++ b/mountd/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
+AM_CFLAGS = -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) $(LIBKRB5_CFLAGS) -fno-common
 LIBS = $(GLIB_LIBS) $(LIBNL_LIBS) $(LIBKRB5_LIBS)
 ksmbd_mountd_LDADD = $(top_builddir)/lib/libksmbdtools.a
 


### PR DESCRIPTION
In MIT Kerberos krb5_rd_req ends up setting both initiator and acceptor
subkeys while Heimdal Kerberos only sets the former:
https://github.com/krb5/krb5/blob/krb5-1.19.2-final/src/lib/krb5/krb/rd_req_dec.c#L730-L743
https://github.com/heimdal/heimdal/blob/f34394f/lib/krb5/rd_req.c#L418-L423
The approach taken follows this:
https://github.com/heimdal/heimdal/blob/f34394f/lib/gssapi/krb5/accept_sec_context.c#L597-L623

The HAVE_KRB5_AUTH_CON_GETRECVSUBKEY and HAVE_KRB5_AUTH_CON_SETSENDSUBKEY
macro blocks deal with krb5_auth_con_getrecvsubkey and
krb5_auth_con_setsendsubkey symbols not being exported even though they are
defined in Heimdal.

The HAVE_KRB5_KEYBLOCK_KEYVALUE macro block is from cifs.upcall of
cifs-utils and was originally contributed there by Torsten Kurbad.

The HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER macro block
deals with the type difference in the krb5_authenticator parameter to
krb5_auth_con_getauthenticator.

The HAVE_KRB5_AUTHENTICATOR_CLIENT macro block builds the
authenticator client principal from krb5_authenticator.
Heimdal has an internal function to do this:
https://github.com/heimdal/heimdal/blob/0e8c4cc/kdc/hpropd.c#L194-L195
Samba vendors Heimdal and some time ago used the function here:
https://github.com/samba-team/samba/blob/1ec8d55/source4/kdc/kpasswdd.c#L315-L317
This is the current approach Samba takes which is replicated in the macro block:
https://github.com/samba-team/samba/blob/bbfaa9b/source4/kdc/kpasswdd.c#L309-L311

Please verify that the approach of copying the initiator subkey to the
acceptor subkey is correct if the former is present.

Also, since this SPNEGO KRB5 functionality is not implemented using libgssapi
found in MIT Kerberos and Heimdal Kerberos, can the handle_krb5_authen
function really be this short? Are there assumptions made here about the negotiation?

Here's how to configure ksmbd-tools against Heimdal in Debian:
```
./configure \
  LIBKRB5_CFLAGS="$(krb5-config.heimdal --cflags)" \
  LIBKRB5_LIBS="$(krb5-config.heimdal --libs) -lcrypt -lroken -lasn1 -lcom_err" \
  --enable-krb5
```

Signed-off-by: atheik \<atteh.mailbox@gmail.com\>