### PR TITLE
add meson build

### DIFF
--- a/addshare/meson.build
+++ b/addshare/meson.build
@@ -1,0 +1,10 @@
+addshare = executable(
+  'ksmbd.addshare',
+  'share_admin.c',
+  'addshare.c',
+  'share_admin.h',
+  dependencies: [glib_dep, netlink_dep],
+  include_directories: tools_incdir,
+  link_with: libksmbdtools,
+  install: true,
+)

--- a/adduser/meson.build
+++ b/adduser/meson.build
@@ -1,0 +1,12 @@
+adduser = executable(
+  'ksmbd.adduser',
+  'md4_hash.c',
+  'user_admin.c',
+  'adduser.c',
+  'md4_hash.h',
+  'user_admin.h',
+  dependencies: [glib_dep, netlink_dep],
+  include_directories: tools_incdir,
+  link_with: libksmbdtools,
+  install: true,
+)

--- a/control/meson.build
+++ b/control/meson.build
@@ -1,0 +1,8 @@
+control = executable(
+  'ksmbd.control',
+  'control.c',
+  dependencies: [glib_dep, netlink_dep],
+  include_directories: tools_incdir,
+  link_with: libksmbdtools,
+  install: true,
+)

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,0 +1,18 @@
+core_files = [
+  'management/tree_conn.c',
+  'management/user.c',
+  'management/share.c',
+  'management/session.c',
+  'config_parser.c',
+  'ksmbdtools.c',
+]
+
+if krb5_dep.found()
+  core_files += [
+    'management/spnego.c',
+    'asn1.c',
+    'management/spnego_krb5.c',
+  ]
+endif
+
+libksmbdtools = static_library('ksmbdtools', core_files, include_directories: tools_incdir, dependencies: [glib_dep, krb5_dep])

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,29 @@
+project('ksmbsd-tools', 'c', version: '3.3.2', default_options: 'c_std=gnu99')
+
+tools_incdir = include_directories(['include', '.'])
+
+glib_dep = dependency('glib-2.0')
+netlink_dep = dependency('libnl-genl-3.0')
+krb5_dep = dependency('krb5', required: get_option('krb5'))
+
+cc = meson.get_compiler('c')
+
+cdata = configuration_data()
+add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
+if krb5_dep.found()
+  cdata.set('CONFIG_KRB5', krb5_dep.found())
+  cdata.set('HAVE_KRB5_KEYBLOCK_KEYVALUE', cc.has_member('krb5_keyblock', 'keyvalue', prefix: '#include <krb5.h>'))
+  cdata.set('HAVE_KRB5_AUTHENTICATOR_CLIENT', cc.has_member('krb5_authenticator', 'client', prefix: '#include <krb5.h>'))
+  cdata.set('HAVE_KRB5_AUTH_CON_GETRECVSUBKEY', cc.has_header_symbol('krb5.h', 'krb5_auth_con_getrecvsubkey'))
+  cdata.set('HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER', true)
+endif
+cfile = configure_file(
+  output: 'config.h',
+  configuration: cdata,
+)
+
+subdir('lib')
+subdir('addshare')
+subdir('adduser')
+subdir('control')
+subdir('mountd')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('krb5', type : 'feature',
+  description : 'Build with Kerberos support',
+)

--- a/mountd/meson.build
+++ b/mountd/meson.build
@@ -1,0 +1,16 @@
+mountd = executable(
+  'ksmbd.mountd',
+  'worker.c',
+  'ipc.c',
+  'rpc.c',
+  'rpc_srvsvc.c',
+  'rpc_wkssvc.c',
+  'mountd.c',
+  'smbacl.c',
+  'rpc_samr.c',
+  'rpc_lsarpc.c',
+  dependencies: [glib_dep, netlink_dep],
+  include_directories: tools_incdir,
+  link_with: libksmbdtools,
+  install: true,
+)


### PR DESCRIPTION
meson compiles faster and is simpler than autotools.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Main motivation was to avoid libiconv problems with OpenWrt.