### PR TITLE
ksmbd-tools: fix meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,8 +14,9 @@ if krb5_dep.found()
   cdata.set('CONFIG_KRB5', krb5_dep.found())
   cdata.set('HAVE_KRB5_KEYBLOCK_KEYVALUE', cc.has_member('krb5_keyblock', 'keyvalue', prefix: '#include <krb5.h>'))
   cdata.set('HAVE_KRB5_AUTHENTICATOR_CLIENT', cc.has_member('krb5_authenticator', 'client', prefix: '#include <krb5.h>'))
-  cdata.set('HAVE_KRB5_AUTH_CON_GETRECVSUBKEY', cc.has_header_symbol('krb5.h', 'krb5_auth_con_getrecvsubkey'))
-  cdata.set('HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER', true)
+  cdata.set('HAVE_KRB5_AUTH_CON_GETRECVSUBKEY', cc.has_function('krb5_auth_con_getrecvsubkey', dependencies: krb5_dep))
+  cdata.set('HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER', cc.compiles('''#include <krb5.h>
+    krb5_error_code krb5_auth_con_getauthenticator(krb5_context, krb5_auth_context, krb5_authenticator**);''', dependencies: krb5_dep))
 endif
 cfile = configure_file(
   output: 'config.h',


### PR DESCRIPTION
The HAVE_KRB5_AUTH_CON_GETRECVSUBKEY macro block deals with the
krb5_auth_con_getrecvsubkey symbol not being exported even though it is
defined in Heimdal. It is \*not* sufficient to check whether it has a
declaration in the krb5.h header file.

The HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER macro block
deals with the type difference in the krb5_authenticator parameter to
krb5_auth_con_getauthenticator. For an unknown reason, this check was
hardcoded as true in the meson build.

Here's how to configure ksmbd-tools against Heimdal in Debian:
```sh
mkdir build
cd build
meson \
  -Dc_args="$(krb5-config.heimdal --cflags)" \
  -Dc_link_args="$(krb5-config.heimdal --libs) -lasn1" \
  ..
```

Signed-off-by: atheik \<atteh.mailbox@gmail.com>