### PR TITLE
fix gcc fanalyzer issues

### DIFF
--- a/lib/asn1.c
+++ b/lib/asn1.c
@@ -201,6 +201,8 @@ unsigned char asn1_read(struct asn1_ctx *ctx,
 	}
 
 	*buf = malloc(len);
+	if (!*buf)
+		return 0;
 	memcpy(*buf, ctx->pointer, len);
 	ctx->pointer += len;
 	return 1;

--- a/lib/management/share.c
+++ b/lib/management/share.c
@@ -671,7 +671,7 @@ int shm_lookup_hosts_map(struct ksmbd_share *share,
 			  enum share_hosts map,
 			  char *host)
 {
-	GHashTable *lookup_map;
+	GHashTable *lookup_map = NULL;
 	int ret = -ENOENT;
 
 	if (map >= KSMBD_SHARE_HOSTS_MAX) {

--- a/lib/management/spnego_krb5.c
+++ b/lib/management/spnego_krb5.c
@@ -113,11 +113,12 @@ static int parse_service_full_name(char *service_full_name,
 	*host_name = strndup(name, delim - name);
 	if (*host_name == NULL) {
 		free(*service_name);
+		*service_name = NULL;
 		return -ENOMEM;
 	}
 out:
 	/* we assume the host name is FQDN if it has "." */
-	if (strchr(*host_name, '.'))
+	if (*host_name && strchr(*host_name, '.'))
 		return 0;
 
 	free(*service_name);


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

The free removal is to avoid a double free.