### PR TITLE
replace calloc with g_malloc0

### DIFF
--- a/adduser/user_admin.c
+++ b/adduser/user_admin.c
@@ -64,8 +64,8 @@ static void term_toggle_echo(int on_off)
 
 static char *__prompt_password_stdin(size_t *sz)
 {
-	char *pswd1 = calloc(1, MAX_NT_PWD_LEN + 1);
-	char *pswd2 = calloc(1, MAX_NT_PWD_LEN + 1);
+	char *pswd1 = g_try_malloc0(MAX_NT_PWD_LEN + 1);
+	char *pswd2 = g_try_malloc0(MAX_NT_PWD_LEN + 1);
 	size_t len = 0;
 	int i;
 
@@ -187,7 +187,7 @@ static char *get_hashed_b64_password(void)
 	if (!pswd_plain)
 		return NULL;
 
-	pswd_hash = calloc(1, sizeof(mctx.hash) + 1);
+	pswd_hash = g_try_malloc0(sizeof(mctx.hash) + 1);
 	if (!pswd_hash) {
 		free(pswd_plain);
 		pr_err("Out of memory\n");

--- a/lib/asn1.c
+++ b/lib/asn1.c
@@ -237,7 +237,7 @@ asn1_oid_decode(struct asn1_ctx *ctx,
 	if (size < 2 || size > UINT_MAX/sizeof(unsigned long))
 		return 0;
 
-	*oid = calloc(size, sizeof(unsigned long));
+	*oid = g_try_malloc0_n(size, sizeof(unsigned long));
 	if (*oid == NULL)
 		return 0;
 
@@ -312,7 +312,7 @@ int asn1_oid_encode(const unsigned long *in_oid, int in_len,
 	unsigned long id;
 	int i;
 
-	*out_oid = calloc(1, in_len * 5);
+	*out_oid = g_try_malloc0_n(in_len, 5);
 	if (*out_oid == NULL)
 		return -ENOMEM;
 

--- a/lib/management/session.c
+++ b/lib/management/session.c
@@ -39,7 +39,7 @@ static struct ksmbd_session *new_ksmbd_session(unsigned long long id,
 {
 	struct ksmbd_session *sess;
 
-	sess = calloc(1, sizeof(struct ksmbd_session));
+	sess = g_try_malloc0(sizeof(struct ksmbd_session));
 	if (!sess)
 		return NULL;
 

--- a/lib/management/share.c
+++ b/lib/management/share.c
@@ -188,7 +188,7 @@ static struct ksmbd_share *new_ksmbd_share(void)
 	struct ksmbd_share *share;
 	int i;
 
-	share = calloc(1, sizeof(struct ksmbd_share));
+	share = g_try_malloc0(sizeof(struct ksmbd_share));
 	if (!share)
 		return NULL;
 

--- a/lib/management/spnego.c
+++ b/lib/management/spnego.c
@@ -250,7 +250,7 @@ static int encode_negTokenTarg(char *in_blob, int in_len,
 
 	*out_len = asn1_header_len(
 			neg_result_len + sup_mech_len + rep_token_len, 2);
-	*out_blob = calloc(1, *out_len);
+	*out_blob = g_try_malloc0(*out_len);
 	if (*out_blob == NULL)
 		return -ENOMEM;
 	buf = *out_blob;

--- a/lib/management/spnego_krb5.c
+++ b/lib/management/spnego_krb5.c
@@ -337,7 +337,7 @@ static int setup_krb5_ctx(struct spnego_mech_ctx *mech_ctx)
 	struct spnego_krb5_ctx *krb5_ctx;
 	krb5_error_code krb_retval;
 
-	krb5_ctx = calloc(1, sizeof(*krb5_ctx));
+	krb5_ctx = g_try_malloc0(sizeof(*krb5_ctx));
 	if (!krb5_ctx)
 		return -ENOMEM;
 

--- a/lib/management/tree_conn.c
+++ b/lib/management/tree_conn.c
@@ -20,7 +20,7 @@ static struct ksmbd_tree_conn *new_ksmbd_tree_conn(void)
 {
 	struct ksmbd_tree_conn *conn;
 
-	conn = calloc(1, sizeof(struct ksmbd_tree_conn));
+	conn = g_try_malloc0(sizeof(struct ksmbd_tree_conn));
 	if (!conn)
 		return NULL;
 

--- a/lib/management/user.c
+++ b/lib/management/user.c
@@ -97,7 +97,7 @@ static struct ksmbd_user *new_ksmbd_user(char *name, char *pwd)
 	struct passwd *passwd;
 	size_t pass_sz;
 
-	user = calloc(1, sizeof(struct ksmbd_user));
+	user = g_try_malloc0(sizeof(struct ksmbd_user));
 	if (!user)
 		return NULL;
 

--- a/mountd/ipc.c
+++ b/mountd/ipc.c
@@ -34,7 +34,7 @@ struct ksmbd_ipc_msg *ipc_msg_alloc(size_t sz)
 	if (msg_sz > KSMBD_IPC_MAX_MESSAGE_SIZE)
 		pr_err("IPC message is too large: %zu\n", msg_sz);
 
-	msg = calloc(1, msg_sz);
+	msg = g_try_malloc0(msg_sz);
 	if (msg)
 		msg->sz = sz;
 	return msg;

--- a/mountd/mountd.c
+++ b/mountd/mountd.c
@@ -129,7 +129,7 @@ char *make_path_subauth(void)
 			}
 	}
 
-	path = calloc(1, loc + strlen(subauth_filename) + 1);
+	path = g_try_malloc0(loc + strlen(subauth_filename) + 1);
 	if (!path)
 		return NULL;
 

--- a/mountd/rpc.c
+++ b/mountd/rpc.c
@@ -119,11 +119,11 @@ static struct ksmbd_dcerpc *dcerpc_alloc(unsigned int flags, int sz)
 {
 	struct ksmbd_dcerpc *dce;
 
-	dce = calloc(1, sizeof(struct ksmbd_dcerpc));
+	dce = g_try_malloc0(sizeof(struct ksmbd_dcerpc));
 	if (!dce)
 		return NULL;
 
-	dce->payload = calloc(1, sz);
+	dce->payload = g_try_malloc0(sz);
 	if (!dce->payload) {
 		free(dce);
 		return NULL;
@@ -144,7 +144,7 @@ static struct ksmbd_dcerpc *dcerpc_ext_alloc(unsigned int flags,
 {
 	struct ksmbd_dcerpc *dce;
 
-	dce = calloc(1, sizeof(struct ksmbd_dcerpc));
+	dce = g_try_malloc0(sizeof(struct ksmbd_dcerpc));
 	if (!dce)
 		return NULL;
 
@@ -200,7 +200,7 @@ static struct ksmbd_rpc_pipe *rpc_pipe_alloc(void)
 {
 	struct ksmbd_rpc_pipe *pipe;
 
-	pipe = calloc(1, sizeof(struct ksmbd_rpc_pipe));
+	pipe = g_try_malloc0(sizeof(struct ksmbd_rpc_pipe));
 	if (!pipe)
 		return NULL;
 
@@ -913,7 +913,7 @@ static int dcerpc_parse_bind_req(struct ksmbd_dcerpc *dce,
 	if (!hdr->num_contexts)
 		return 0;
 
-	hdr->list = calloc(hdr->num_contexts, sizeof(struct dcerpc_context));
+	hdr->list = g_try_malloc0_n(hdr->num_contexts, sizeof(struct dcerpc_context));
 	if (!hdr->list)
 		return -ENOMEM;
 
@@ -931,7 +931,7 @@ static int dcerpc_parse_bind_req(struct ksmbd_dcerpc *dce,
 
 		__dcerpc_read_syntax(dce, &ctx->abstract_syntax);
 
-		ctx->transfer_syntaxes = calloc(ctx->num_syntaxes,
+		ctx->transfer_syntaxes = g_try_malloc0_n(ctx->num_syntaxes,
 						sizeof(struct dcerpc_syntax));
 		if (!ctx->transfer_syntaxes) {
 			ret = -ENOMEM;

--- a/mountd/rpc_lsarpc.c
+++ b/mountd/rpc_lsarpc.c
@@ -59,7 +59,7 @@ static struct policy_handle *lsarpc_ph_alloc(unsigned int id)
 	struct policy_handle *ph;
 	int ret;
 
-	ph = calloc(1, sizeof(struct policy_handle));
+	ph = g_try_malloc(sizeof(struct policy_handle));
 	if (!ph)
 		return NULL;
 
@@ -239,7 +239,7 @@ static int lsarpc_lookup_sid2_invoke(struct ksmbd_rpc_pipe *pipe)
 		struct passwd *passwd;
 		int rid;
 
-		ni = calloc(1, sizeof(struct lsarpc_names_info));
+		ni = g_try_malloc0(sizeof(struct lsarpc_names_info));
 		if (!ni)
 			break;
 

--- a/mountd/rpc_samr.c
+++ b/mountd/rpc_samr.c
@@ -60,7 +60,7 @@ static struct connect_handle *samr_ch_alloc(unsigned int id)
 	struct connect_handle *ch;
 	int ret;
 
-	ch = calloc(1, sizeof(struct connect_handle));
+	ch = g_try_malloc0(sizeof(struct connect_handle));
 	if (!ch)
 		return NULL;
 
@@ -377,7 +377,7 @@ static int samr_query_user_info_return(struct ksmbd_rpc_pipe *pipe)
 	gethostname(hostname, NAME_MAX);
 	home_dir_len = 2 + strlen(hostname) + 1 + strlen(ch->user->name);
 
-	home_dir = calloc(1, home_dir_len);
+	home_dir = g_try_malloc0(home_dir_len);
 	if (!home_dir)
 		return KSMBD_RPC_ENOMEM;
 
@@ -387,7 +387,7 @@ static int samr_query_user_info_return(struct ksmbd_rpc_pipe *pipe)
 	strcat(home_dir, "\\");
 	strcat(home_dir, ch->user->name);
 
-	profile_path = calloc(1, home_dir_len + strlen("profile"));
+	profile_path = g_try_malloc0(home_dir_len + strlen("profile"));
 	if (!profile_path) {
 		free(home_dir);
 		return KSMBD_RPC_ENOMEM;


### PR DESCRIPTION
Allows getting rid of the NULL checks. g_malloc0 terminates the program
instead of returning NULL.

Signed-off-by: Rosen Penev <rosenp@gmail.com>