### PR TITLE
More build fixes

### DIFF
--- a/README
+++ b/README
@@ -30,10 +30,10 @@ Setup steps:
 	- install smbd kernel driver
 		modprobe ksmbd
 	- create user/password for SMB share
-		mkdir /etc/ksmbd/
+		mkdir -p /usr/local/etc/ksmbd/
 		ksmbd.adduser -a <Enter USERNAME for SMB share access>
 		Enter password for SMB share access
-	- create /etc/ksmbd/smb.conf file, add SMB share in smb.conf file
+	- create /usr/local/etc/ksmbd/smb.conf file, add SMB share in smb.conf file
 		Refer smb.conf.example
 	- start smbd user space daemon
 		ksmbd.mountd

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ All administration tasks must be done as root.
 - Install ksmbd kernel driver
 	- `modprobe ksmbd`
 - Create user/password for SMB share
-	- `mkdir /etc/ksmbd`
+	- `mkdir -p /usr/local/etc/ksmbd`
 	- `ksmbd.adduser -a <username>`
 	- Enter password for SMB share access
-- Create `/etc/ksmbd/smb.conf` file
+- Create `/usr/local/etc/ksmbd/smb.conf` file
 	- Refer `smb.conf.example`
 - Add share to `smb.conf`
 	- This can be done manually or with `ksmbd.addshare`, e.g.:
@@ -78,11 +78,11 @@ smb, auth, vfs, oplock, ipc, conn, rdma
 
 - ksmbd.adduser
   - Adds (-a), updates (-u), or deletes (-d) a user from user database.
-  - Default database file is `/etc/ksmbd/users.db`
+  - Default database file is `/usr/local/etc/ksmbd/users.db`
 
 - ksmbd.addshare
   - Adds (-a), updates (-u), or deletes (-d) a net share from config file.
-  - Default config file is `/etc/ksmbd/smb.conf`
+  - Default config file is `/usr/local/etc/ksmbd/smb.conf`
 
 `ksmbd.addshare` does not modify `[global]` section in config file; only net
 share configs are supported at the moment.

--- a/addshare/Makefile.am
+++ b/addshare/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
+AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
 LIBS = $(GLIB_LIBS)
 ksmbd_addshare_LDADD = $(top_builddir)/lib/libksmbdtools.a
 

--- a/addshare/meson.build
+++ b/addshare/meson.build
@@ -8,4 +8,5 @@ addshare = executable(
   link_with: libksmbdtools,
   install: true,
   install_dir: get_option('sbindir'),
+  c_args: '-DSYSCONFDIR="@0@"'.format(get_option('prefix') / get_option('sysconfdir')),
 )

--- a/addshare/meson.build
+++ b/addshare/meson.build
@@ -7,4 +7,5 @@ addshare = executable(
   include_directories: tools_incdir,
   link_with: libksmbdtools,
   install: true,
+  install_dir: get_option('sbindir'),
 )

--- a/adduser/Makefile.am
+++ b/adduser/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
+AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
 LIBS = $(GLIB_LIBS)
 ksmbd_adduser_LDADD = $(top_builddir)/lib/libksmbdtools.a
 

--- a/adduser/meson.build
+++ b/adduser/meson.build
@@ -10,4 +10,5 @@ adduser = executable(
   link_with: libksmbdtools,
   install: true,
   install_dir: get_option('sbindir'),
+  c_args: '-DSYSCONFDIR="@0@"'.format(get_option('prefix') / get_option('sysconfdir')),
 )

--- a/adduser/meson.build
+++ b/adduser/meson.build
@@ -9,4 +9,5 @@ adduser = executable(
   include_directories: tools_incdir,
   link_with: libksmbdtools,
   install: true,
+  install_dir: get_option('sbindir'),
 )

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ AS_IF([test "$has_libnl_ver" -eq 0], [
 
 if test "$enable_krb5" != "no"; then
 	PKG_CHECK_MODULES([LIBKRB5], [krb5])
-	AC_DEFINE([CONFIG_KRB5], [], "support kerberos authentication")
+	AC_DEFINE([CONFIG_KRB5], [], [Define if Kerberos 5 authentication is supported.])
 	ksmbd_tools_LIBS=$LIBS
 	LIBS="$LIBS $LIBKRB5_LIBS"
 	AC_CHECK_FUNCS([krb5_auth_con_getrecvsubkey])
@@ -65,7 +65,7 @@ if test "$enable_krb5" != "no"; then
 			[ac_cv_have_krb5_keyblock_keyvalue="yes"], [ac_cv_have_krb5_keyblock_keyvalue="no"])
 	])
 	if test "$ac_cv_have_krb5_keyblock_keyvalue" = "yes" ; then
-		AC_DEFINE(HAVE_KRB5_KEYBLOCK_KEYVALUE, [], "the krb5_keyblock struct has a keyvalue property")
+		AC_DEFINE(HAVE_KRB5_KEYBLOCK_KEYVALUE, [], [Define if the krb5_keyblock struct has a keyvalue property.])
 	fi
 	AC_CACHE_CHECK([for double pointer in krb5_auth_con_getauthenticator], [ac_cv_have_krb5_auth_con_getauthenticator_double_pointer], [
 		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <krb5.h>
@@ -73,14 +73,14 @@ if test "$enable_krb5" != "no"; then
 			[ac_cv_have_krb5_auth_con_getauthenticator_double_pointer="yes"], [ac_cv_have_krb5_auth_con_getauthenticator_double_pointer="no"])
 	])
 	if test "$ac_cv_have_krb5_auth_con_getauthenticator_double_pointer" = "yes" ; then
-		AC_DEFINE(HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER, [], "the krb5_auth_con_getauthenticator function takes a double pointer")
+		AC_DEFINE(HAVE_KRB5_AUTH_CON_GETAUTHENTICATOR_DOUBLE_POINTER, [], [Define if the krb5_auth_con_getauthenticator function takes a double pointer.])
 	fi
 	AC_CACHE_CHECK([for client in krb5_authenticator], [ac_cv_have_krb5_authenticator_client], [
 		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <krb5.h>], [krb5_authenticator authenti; authenti.client = NULL;])],
 			[ac_cv_have_krb5_authenticator_client="yes"], [ac_cv_have_krb5_authenticator_client="no"])
 	])
 	if test "$ac_cv_have_krb5_authenticator_client" = "yes" ; then
-		AC_DEFINE(HAVE_KRB5_AUTHENTICATOR_CLIENT, [], "the krb5_authenticator struct has a client property")
+		AC_DEFINE(HAVE_KRB5_AUTHENTICATOR_CLIENT, [], [Define if the krb5_authenticator struct has a client property.])
 	fi
 fi
 AM_CONDITIONAL(HAVE_LIBKRB5, [test "$enable_krb5" != "no"])

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,7 @@
 AC_PREREQ([2.68])
 
-m4_define([ksmbd_tools_version], m4_esyscmd_s(
-	 grep "define KSMBD_TOOLS_VERSION " include/version.h | \
-		 awk '{print $3}' | sed 's/\"//g'))
+m4_define([ksmbd_tools_version], m4_esyscmd_s([awk '/define KSMBD_TOOLS_VERSION / \
+	{ gsub(/"/,"",$3); printf "%s", $3 }' include/version.h]))
 
 AC_INIT([ksmbd-tools],
 	ksmbd_tools_version,

--- a/control/meson.build
+++ b/control/meson.build
@@ -5,4 +5,5 @@ control = executable(
   include_directories: tools_incdir,
   link_with: libksmbdtools,
   install: true,
+  install_dir: get_option('sbindir'),
 )

--- a/include/ksmbdtools.h
+++ b/include/ksmbdtools.h
@@ -86,8 +86,8 @@ extern struct smbconf_global global_conf;
 
 #define KSMBD_CONF_FILE_MAX		10000
 
-#define PATH_PWDDB	"/etc/ksmbd/ksmbdpwd.db"
-#define PATH_SMBCONF	"/etc/ksmbd/smb.conf"
+#define PATH_PWDDB	SYSCONFDIR "/ksmbd/ksmbdpwd.db"
+#define PATH_SMBCONF	SYSCONFDIR "/ksmbd/smb.conf"
 
 #define KSMBD_HEALTH_START		(0)
 #define KSMBD_HEALTH_RUNNING		(1 << 0)

--- a/include/ksmbdtools.h
+++ b/include/ksmbdtools.h
@@ -82,7 +82,7 @@ extern struct smbconf_global global_conf;
 #define KSMBD_CONF_FALLBACK_GUEST_ACCOUNT	"ftp"
 
 #define KSMBD_CONF_DEFAULT_SESS_CAP	1024
-#define KSMBD_CONF_DEFAULT_TPC_PORT	445
+#define KSMBD_CONF_DEFAULT_TCP_PORT	445
 
 #define KSMBD_CONF_FILE_MAX		10000
 

--- a/lib/config_parser.c
+++ b/lib/config_parser.c
@@ -590,7 +590,7 @@ static void global_conf_fixup_missing(void)
 		global_conf.work_group =
 			cp_get_group_kv_string(KSMBD_CONF_DEFAULT_WORK_GROUP);
 	if (!global_conf.tcp_port)
-		global_conf.tcp_port = KSMBD_CONF_DEFAULT_TPC_PORT;
+		global_conf.tcp_port = KSMBD_CONF_DEFAULT_TCP_PORT;
 
 	if (global_conf.sessions_cap <= 0)
 		global_conf.sessions_cap = KSMBD_CONF_DEFAULT_SESS_CAP;

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,7 @@
-project('ksmbsd-tools', 'c', version: '3.3.2', default_options: 'c_std=gnu99')
+project('ksmbsd-tools', 'c',
+  version: run_command(find_program('awk'), '''/define KSMBD_TOOLS_VERSION / \
+    { gsub(/"/,"",$3); printf "%s", $3 }''', 'include/version.h', check: true).stdout(),
+  default_options: 'c_std=gnu99')
 
 tools_incdir = include_directories(['include', '.'])
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('krb5', type : 'feature',
   description : 'Build with Kerberos support',
+  value : 'disabled',
 )

--- a/mountd/Makefile.am
+++ b/mountd/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) $(LIBKRB5_CFLAGS) -fno-common
+AM_CFLAGS = -DSYSCONFDIR='"${sysconfdir}"' -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) $(LIBKRB5_CFLAGS) -fno-common
 LIBS = $(GLIB_LIBS) $(LIBNL_LIBS) $(LIBKRB5_LIBS)
 ksmbd_mountd_LDADD = $(top_builddir)/lib/libksmbdtools.a
 

--- a/mountd/meson.build
+++ b/mountd/meson.build
@@ -14,4 +14,5 @@ mountd = executable(
   link_with: libksmbdtools,
   install: true,
   install_dir: get_option('sbindir'),
+  c_args: '-DSYSCONFDIR="@0@"'.format(get_option('prefix') / get_option('sysconfdir')),
 )

--- a/mountd/meson.build
+++ b/mountd/meson.build
@@ -13,4 +13,5 @@ mountd = executable(
   include_directories: tools_incdir,
   link_with: libksmbdtools,
   install: true,
+  install_dir: get_option('sbindir'),
 )


### PR DESCRIPTION
ksmbd-tools: fix typoed macro identifier
ksmbd-tools: redo project version extraction and use it in meson build
ksmbd-tools: fix kerberos related autoconf quoting
ksmbd-tools: disable krb5 by default in meson build
ksmbd-tools: install programs to sbindir in meson build
ksmbd-tools: respect sysconfdir

Signed-off-by: atheik \<atteh.mailbox@gmail.com>