### PR TITLE
ksmbd-tools: fix memory leak at cp_add_ipc_share()

### DIFF
--- a/lib/config_parser.c
+++ b/lib/config_parser.c
@@ -649,11 +649,7 @@ static int cp_add_ipc_share(void)
 	if (ret) {
 		pr_err("Unable to add IPC$ share\n");
 		ret = -EINVAL;
-		goto out;
 	}
-	return ret;
-
-out:
 	g_free(comment);
 	g_free(guest);
 	return ret;


### PR DESCRIPTION
The variables comment and guest are passed to add_group_key_value(),
which copies them, and so should be freed regardless of whether the
function returns an error.

Signed-off-by: atheik \<atteh.mailbox@gmail.com>