### PR TITLE
ksmbd-tools: fix segfault at spnego_destroy()

### DIFF
--- a/lib/management/spnego.c
+++ b/lib/management/spnego.c
@@ -78,7 +78,7 @@ void spnego_destroy(void)
 	int i;
 
 	for (i = 0; i < SPNEGO_MAX_MECHS; i++) {
-		if (mech_ctxs[i].ops->cleanup)
+		if (mech_ctxs[i].ops && mech_ctxs[i].ops->cleanup)
 			mech_ctxs[i].ops->cleanup(&mech_ctxs[i]);
 	}
 }


### PR DESCRIPTION
Fix a segfault that happened when ksmbd.mountd is started without
permissions to read the ksmbdpwd.db file. Check that the ops member of
spnego_mech_ctx is non-null before dereferencing it and accessing the
cleanup member.

Signed-off-by: atheik \<atteh.mailbox@gmail.com>