### PR TITLE
Improve usage strings and argument handling

### DIFF
--- a/addshare/addshare.c
+++ b/addshare/addshare.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
 		case 'h':
 		default:
 			usage();
-	}
+		}
 
 	if (cmd != COMMAND_DEL_SHARE && !arg_opts) {
 		usage();

--- a/addshare/addshare.c
+++ b/addshare/addshare.c
@@ -120,7 +120,7 @@ static int sanity_check_share_name_simple(char *name)
 	if (sz >= KSMBD_REQ_MAX_SHARE_NAME)
 		return -EINVAL;
 
-	if (!cp_key_cmp(name, "global"))
+	if (!g_ascii_strcasecmp(name, "global"))
 		return -EINVAL;
 
 	return 0;

--- a/addshare/addshare.c
+++ b/addshare/addshare.c
@@ -113,7 +113,6 @@ int main(int argc, char *argv[])
 
 	set_logger_app_name("ksmbd.addshare");
 
-	opterr = 0;
 	while ((c = getopt_long(argc, argv, "c:a:d:u:p:o:Vvh", opts, NULL)) != EOF)
 		switch (c) {
 		case 'a':

--- a/addshare/addshare.c
+++ b/addshare/addshare.c
@@ -59,8 +59,10 @@ static const struct option opts[] = {
 	{"del-share",		required_argument,	NULL,	'd' },
 	{"update-share",	required_argument,	NULL,	'u' },
 	{"options",		required_argument,	NULL,	'o' },
+	{"config",		required_argument,	NULL,	'c' },
 	{"version",		no_argument,		NULL,	'V' },
 	{"verbose",		no_argument,		NULL,	'v' },
+	{"help",		no_argument,		NULL,	'h' },
 	{NULL,			0,			NULL,	 0  }
 };
 

--- a/addshare/addshare.c
+++ b/addshare/addshare.c
@@ -33,25 +33,46 @@ enum {
 	COMMAND_UPDATE_SHARE,
 };
 
-static void usage(void)
+static void usage(int status)
 {
 	int i;
 
-	fprintf(stderr, "Usage: smbshareadd\n");
+	fprintf(stderr,
+	        "Usage: ksmbd.addshare {-a SHARE | -u SHARE} {-o OPTIONS} [-c SMBCONF] [-v]\n"
+	        "       ksmbd.addshare {-d SHARE} [-c SMBCONF] [-v]\n"
+	        "       ksmbd.addshare {-V | -h}\n");
 
-	fprintf(stderr, "\t-a | --add-share=share\n");
-	fprintf(stderr, "\t-d | --del-share=share\n");
-	fprintf(stderr, "\t-u | --update-share=share\n");
-	fprintf(stderr, "\t-o | --options=\"op1=val1 op2=val2...\"\n");
-
-	fprintf(stderr, "\t-c smb.conf\n");
-	fprintf(stderr, "\t-V | --version\n");
-	fprintf(stderr, "\t-v | --verbose\n");
-
-	fprintf(stderr, "Supported share options:\n");
-	for (i = 0; i < KSMBD_SHARE_CONF_MAX; i++)
-		fprintf(stderr, "\t%s\n", KSMBD_SHARE_CONF[i]);
-	exit(EXIT_FAILURE);
+	if (status != EXIT_SUCCESS)
+		fprintf(stderr, "Try 'ksmbd.addshare --help' for more information.\n");
+	else {
+		fprintf(stderr,
+		        "Configure shares for config file of ksmbd.mountd user mode daemon.\n"
+		        "\n"
+		        "Mandatory arguments to long options are mandatory for short options too.\n"
+		        "  -a, --add-share=SHARE       add SHARE to config file;\n"
+		        "                              SHARE is 1 to " STR(KSMBD_REQ_MAX_SHARE_NAME) " characters;\n"
+		        "                              SHARE cannot be 'global';\n"
+		        "                              you must also give option 'options'\n"
+		        "  -d, --del-share=SHARE       delete SHARE from config file;\n"
+		        "                              you must restart ksmbd for changes to take effect\n"
+		        "  -u, --update-share=SHARE    update SHARE in config file;\n"
+		        "                              you must also give option 'options';\n"
+		        "                              you must restart ksmbd for changes to take effect\n"
+		        "  -o, --options=OPTIONS       provide OPTIONS for share;\n"
+		        "                              OPTIONS has format 'key1=val1 key2=val2'\n"
+		        "  -c, --config=SMBCONF        use SMBCONF as config file instead of\n"
+		        "                              '" PATH_SMBCONF "'\n"
+		        "  -v, --verbose               be more verbose; unimplemented\n"
+		        "  -V, --version               output version information and exit\n"
+		        "  -h, --help                  display this help and exit\n"
+		        "\n"
+		        "The following OPTIONS are supported:\n");
+		for (i = 0; i < KSMBD_SHARE_CONF_MAX; i++)
+			fprintf(stderr, "  %s\n", KSMBD_SHARE_CONF[i]);
+		fprintf(stderr,
+		        "\n"
+		        "ksmbd-tools home page: <https://github.com/cifsd-team/ksmbd-tools>\n");
+	}
 }
 
 static const struct option opts[] = {
@@ -66,10 +87,10 @@ static const struct option opts[] = {
 	{NULL,			0,			NULL,	 0  }
 };
 
-static void show_version(void)
+static int show_version(void)
 {
 	printf("ksmbd-tools version : %s\n", KSMBD_TOOLS_VERSION);
-	exit(EXIT_FAILURE);
+	return EXIT_SUCCESS;
 }
 
 static int parse_configs(char *smbconf)
@@ -134,23 +155,36 @@ int main(int argc, char *argv[])
 			arg_opts = strdup(optarg);
 			break;
 		case 'V':
-			show_version();
-			break;
+			ret = show_version();
+			goto out;
 		case 'v':
 			break;
-		case '?':
 		case 'h':
+			ret = EXIT_SUCCESS;
+			/* Fall through */
+		case '?':
 		default:
-			usage();
+			usage(ret);
+			goto out;
 		}
 
+	if (argc < 2 || argc > optind) {
+		usage(ret);
+		goto out;
+	}
+
+	if (!arg_name) {
+		pr_err("No option with share name given\n");
+		goto out;
+	}
+
 	if (cmd != COMMAND_DEL_SHARE && !arg_opts) {
-		usage();
-		return -1;
+		pr_err("No options for share given\n");
+		goto out;
 	}
 
 	if (sanity_check_share_name_simple(arg_name)) {
-		pr_err("share name sanity check failure\n");
+		pr_err("Share name sanity check failure\n");
 		goto out;
 	}
 

--- a/adduser/adduser.c
+++ b/adduser/adduser.c
@@ -58,6 +58,7 @@ static const struct option opts[] = {
 	{"import-users",	required_argument,	NULL,	'i' },
 	{"version",		no_argument,		NULL,	'V' },
 	{"verbose",		no_argument,		NULL,	'v' },
+	{"help",		no_argument,		NULL,	'h' },
 	{NULL,			0,			NULL,	 0  }
 };
 

--- a/adduser/adduser.c
+++ b/adduser/adduser.c
@@ -113,7 +113,6 @@ int main(int argc, char *argv[])
 
 	set_logger_app_name("ksmbd.adduser");
 
-	opterr = 0;
 	while ((c = getopt_long(argc, argv, "c:i:a:d:u:p:Vvh", opts, NULL)) != EOF)
 		switch (c) {
 		case 'a':

--- a/adduser/adduser.c
+++ b/adduser/adduser.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
 		case 'h':
 		default:
 			usage();
-	}
+		}
 
 	if (sanity_check_user_name_simple(arg_account)) {
 		pr_err("User name sanity check failure\n");

--- a/adduser/adduser.c
+++ b/adduser/adduser.c
@@ -34,20 +34,39 @@ enum {
 	COMMAND_UPDATE_USER,
 };
 
-static void usage(void)
+static void usage(int status)
 {
-	fprintf(stderr, "Usage: smbuseradd\n");
+	fprintf(stderr,
+	        "Usage: ksmbd.adduser {-a USER | -u USER} [-p PWD] [-i PWDDB] [-v]\n"
+	        "       ksmbd.adduser {-d USER} [-i PWDDB] [-v]\n"
+	        "       ksmbd.adduser {-V | -h}\n");
 
-	fprintf(stderr, "\t-a | --add-user=login\n");
-	fprintf(stderr, "\t-d | --del-user=login\n");
-	fprintf(stderr, "\t-u | --update-user=login\n");
-	fprintf(stderr, "\t-p | --password=pass\n");
-
-	fprintf(stderr, "\t-i smbpwd.db | --import-users=smbpwd.db\n");
-	fprintf(stderr, "\t-V | --version\n");
-	fprintf(stderr, "\t-v | --verbose\n");
-
-	exit(EXIT_FAILURE);
+	if (status != EXIT_SUCCESS)
+		fprintf(stderr, "Try 'ksmbd.adduser --help' for more information.\n");
+	else
+		fprintf(stderr,
+		        "Configure users for user database of ksmbd.mountd user mode daemon.\n"
+		        "\n"
+		        "Mandatory arguments to long options are mandatory for short options too.\n"
+		        "  -a, --add-user=USER         add USER to user database;\n"
+		        "                              USER is 1 to " STR(KSMBD_REQ_MAX_ACCOUNT_NAME_SZ) " characters;\n"
+		        "                              USER cannot contain ':' or '\\n';\n"
+		        "                              USER cannot be 'root'\n"
+		        "  -d, --del-user=USER         delete USER from user database;\n"
+		        "                              you must restart ksmbd for changes to take effect\n"
+		        "  -u, --update-user=USER      update USER in user database;\n"
+		        "                              you must restart ksmbd for changes to take effect\n"
+		        "  -p, --password=PWD          provide PWD for user;\n"
+		        "                              PWD is 0 to " STR(MAX_NT_PWD_LEN) " characters;\n"
+		        "                              PWD cannot contain '\\n'\n"
+		        "  -i, --import-users=PWDDB    use PWDDB as user database instead of\n"
+		        "                              '" PATH_PWDDB "';\n"
+		        "                              this option does nothing by itself\n"
+		        "  -v, --verbose               be more verbose; unimplemented\n"
+		        "  -V, --version               output version information and exit\n"
+		        "  -h, --help                  display this help and exit\n"
+		        "\n"
+		        "ksmbd-tools home page: <https://github.com/cifsd-team/ksmbd-tools>\n");
 }
 
 static const struct option opts[] = {
@@ -62,10 +81,10 @@ static const struct option opts[] = {
 	{NULL,			0,			NULL,	 0  }
 };
 
-static void show_version(void)
+static int show_version(void)
 {
 	printf("ksmbd-tools version : %s\n", KSMBD_TOOLS_VERSION);
-	exit(EXIT_FAILURE);
+	return EXIT_SUCCESS;
 }
 
 static int parse_configs(char *pwddb)
@@ -134,15 +153,28 @@ int main(int argc, char *argv[])
 			pwddb = g_strdup(optarg);
 			break;
 		case 'V':
-			show_version();
-			break;
+			ret = show_version();
+			goto out;
 		case 'v':
 			break;
-		case '?':
 		case 'h':
+			ret = EXIT_SUCCESS;
+			/* Fall through */
+		case '?':
 		default:
-			usage();
+			usage(ret);
+			goto out;
 		}
+
+	if (argc < 2 || argc > optind) {
+		usage(ret);
+		goto out;
+	}
+
+	if (!arg_account) {
+		pr_err("No option with user name given\n");
+		goto out;
+	}
 
 	if (sanity_check_user_name_simple(arg_account)) {
 		pr_err("User name sanity check failure\n");

--- a/adduser/user_admin.c
+++ b/adduser/user_admin.c
@@ -24,8 +24,6 @@
 
 #include <linux/ksmbd_server.h>
 
-#define MAX_NT_PWD_LEN 129
-
 static char *arg_account = NULL;
 static char *arg_password = NULL;
 static int conf_fd = -1;

--- a/adduser/user_admin.h
+++ b/adduser/user_admin.h
@@ -8,6 +8,8 @@
 #ifndef __KSMBD_USER_ADMIN_H__
 #define __KSMBD_USER_ADMIN_H__
 
+#define MAX_NT_PWD_LEN 129
+
 int command_add_user(char *pwddb, char *account, char *password);
 int command_update_user(char *pwddb, char *account, char *password);
 int command_del_user(char *pwddb, char *account);

--- a/control/control.c
+++ b/control/control.c
@@ -87,6 +87,9 @@ static int ksmbd_control_debug(char *comp)
 	ret = write(fd, comp, strlen(comp));
 	if (ret < 0)
 		goto out;
+	ret = lseek(fd, 0, SEEK_SET);
+	if (ret < 0)
+		goto out;
 	ret = read(fd, buf, 255);
 	if (ret < 0)
 		goto out;

--- a/control/control.c
+++ b/control/control.c
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
 		case 'h':
 		default:
 			usage();
-	}
+		}
 
 	if (argc < 2)
 		usage();

--- a/control/control.c
+++ b/control/control.c
@@ -109,7 +109,6 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	opterr = 0;
 	while ((c = getopt_long(argc, argv, "sd:cVh", opts, NULL)) != EOF)
 		switch (c) {
 		case 's':

--- a/control/control.c
+++ b/control/control.c
@@ -28,6 +28,7 @@ static const struct option opts[] = {
 	{"debug",		required_argument,	NULL,	'd' },
 	{"ksmbd-version",	no_argument,		NULL,	'c' },
 	{"version",		no_argument,		NULL,	'V' },
+	{"help",		no_argument,		NULL,	'h' },
 	{NULL,			0,			NULL,	 0  }
 };
 

--- a/control/control.c
+++ b/control/control.c
@@ -12,15 +12,29 @@
 #include "ksmbdtools.h"
 #include "version.h"
 
-static void usage(void)
+static void usage(int status)
 {
-	fprintf(stderr, "Usage: ksmbd.control\n");
-	fprintf(stderr, "\t-s | --shutdown\n");
-	fprintf(stderr, "\t-d | --debug=all or [smb, auth, etc...]\n");
-	fprintf(stderr, "\t-c | --ksmbd-version\n");
-	fprintf(stderr, "\t-V | --version\n");
+	fprintf(stderr,
+	        "Usage: ksmbd.control {-s | -d COMPONENT | -c | -V | -h}\n");
 
-	exit(EXIT_FAILURE);
+	if (status != EXIT_SUCCESS)
+		fprintf(stderr, "Try 'ksmbd.control --help' for more information.\n");
+	else
+		fprintf(stderr,
+		        "Control ksmbd.mountd user mode and ksmbd kernel mode daemons.\n"
+		        "\n"
+		        "Mandatory arguments to long options are mandatory for short options too.\n"
+		        "  -s, --shutdown           shutdown ksmbd.mountd and ksmbd\n"
+		        "  -d, --debug=COMPONENT    toggle debug printing for COMPONENT;\n"
+		        "                           COMPONENT is 'smb', 'auth', 'vfs', 'oplock',\n"
+		        "                           'ipc', 'conn', or 'rdma';\n"
+		        "                           output also status of all components;\n"
+		        "                           enabled components are enclosed in brackets\n"
+		        "  -c, --ksmbd-version      output ksmbd version information and exit\n"
+		        "  -V, --version            output version information and exit\n"
+		        "  -h, --help               display this help and exit\n"
+		        "\n"
+		        "ksmbd-tools home page: <https://github.com/cifsd-team/ksmbd-tools>\n");
 }
 
 static const struct option opts[] = {
@@ -32,10 +46,10 @@ static const struct option opts[] = {
 	{NULL,			0,			NULL,	 0  }
 };
 
-static void show_version(void)
+static int show_version(void)
 {
 	printf("ksmbd-tools version : %s\n", KSMBD_TOOLS_VERSION);
-	exit(EXIT_FAILURE);
+	return EXIT_SUCCESS;
 }
 
 static int ksmbd_control_shutdown(void)
@@ -124,16 +138,19 @@ int main(int argc, char *argv[])
 			ret = ksmbd_control_show_version();
 			break;
 		case 'V':
-			show_version();
+			ret = show_version();
 			break;
-		case '?':
 		case 'h':
+			ret = EXIT_SUCCESS;
+			/* Fall through */
+		case '?':
 		default:
-			usage();
+			usage(ret);
+			break;
 		}
 
-	if (argc < 2)
-		usage();
+	if (argc < 2 || argc > optind)
+		usage(ret);
 
 	return ret;
 }

--- a/include/ksmbdtools.h
+++ b/include/ksmbdtools.h
@@ -99,6 +99,9 @@ extern int ksmbd_health_status;
 
 #define ARRAY_SIZE(X) (sizeof(X) / sizeof((X)[0]))
 
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
 //---------------------------------------------------------------//
 #define LOGAPP		"[%s/%d]:"
 #define PRERR		LOGAPP" ERROR: "

--- a/include/ksmbdtools.h
+++ b/include/ksmbdtools.h
@@ -82,7 +82,7 @@ extern struct smbconf_global global_conf;
 #define KSMBD_CONF_FALLBACK_GUEST_ACCOUNT	"ftp"
 
 #define KSMBD_CONF_DEFAULT_SESS_CAP	1024
-#define KSMBD_CONF_DEFAULT_TPC_PORT	445
+#define KSMBD_CONF_DEFAULT_TCP_PORT	445
 
 #define KSMBD_CONF_FILE_MAX		10000
 

--- a/lib/config_parser.c
+++ b/lib/config_parser.c
@@ -590,7 +590,7 @@ static void global_conf_fixup_missing(void)
 		global_conf.work_group =
 			cp_get_group_kv_string(KSMBD_CONF_DEFAULT_WORK_GROUP);
 	if (!global_conf.tcp_port)
-		global_conf.tcp_port = KSMBD_CONF_DEFAULT_TPC_PORT;
+		global_conf.tcp_port = KSMBD_CONF_DEFAULT_TCP_PORT;
 
 	if (global_conf.sessions_cap <= 0)
 		global_conf.sessions_cap = KSMBD_CONF_DEFAULT_SESS_CAP;

--- a/mountd/mountd.c
+++ b/mountd/mountd.c
@@ -566,17 +566,8 @@ int main(int argc, char *argv[])
 	pr_logger_init(PR_LOGGER_STDIO);
 
 	opterr = 0;
-	while (1) {
-		c = getopt_long(argc, argv, "n::p:c:u:sVh", opts, NULL);
-
-		if (c < 0)
-			break;
-
+	while ((c = getopt_long(argc, argv, "n::p:c:u:sVh", opts, NULL)) != EOF)
 		switch (c) {
-		case 0: /* getopt_long() set a variable, just keep going */
-			break;
-		case 1:
-			break;
 		case 'p':
 			global_conf.tcp_port = cp_get_group_kv_long(optarg);
 			pr_debug("TCP port option override\n");
@@ -599,16 +590,11 @@ int main(int argc, char *argv[])
 		case 'V':
 			show_version();
 			break;
-		case ':':
-			pr_err("Missing option argument\n");
-			/* Fall through */
 		case '?':
 		case 'h':
-			/* Fall through */
 		default:
 			usage();
 		}
-	}
 
 	if (!global_conf.smbconf || !global_conf.pwddb) {
 		pr_err("Out of memory\n");

--- a/mountd/mountd.c
+++ b/mountd/mountd.c
@@ -565,7 +565,6 @@ int main(int argc, char *argv[])
 	global_conf.smbconf = PATH_SMBCONF;
 	pr_logger_init(PR_LOGGER_STDIO);
 
-	opterr = 0;
 	while ((c = getopt_long(argc, argv, "n::p:c:u:sVh", opts, NULL)) != EOF)
 		switch (c) {
 		case 'p':

--- a/mountd/mountd.c
+++ b/mountd/mountd.c
@@ -550,7 +550,6 @@ static struct option opts[] = {
 	{"systemd",	no_argument,		NULL,	's' },
 	{"nodetach",	optional_argument,	NULL,	'n' },
 	{"help",	no_argument,		NULL,	'h' },
-	{"?",		no_argument,		NULL,	'?' },
 	{"version",	no_argument,		NULL,	'V' },
 	{NULL,		0,			NULL,	 0  }
 };

--- a/mountd/mountd.c
+++ b/mountd/mountd.c
@@ -39,24 +39,39 @@ static int lock_fd = -1;
 
 typedef int (*worker_fn)(void);
 
-static void usage(void)
+static void usage(int status)
 {
-	fprintf(stderr, "Usage: ksmbd\n");
-	fprintf(stderr, "\t--p=NUM | --port=NUM              TCP port NUM\n");
-	fprintf(stderr, "\t--c=smb.conf | --config=smb.conf  config file\n");
-	fprintf(stderr, "\t--u=pwd.db | --users=pwd.db       Users DB\n");
-	fprintf(stderr, "\t--n | --nodetach                  Don't detach\n");
-	fprintf(stderr, "\t--s | --systemd                   Service mode\n");
-	fprintf(stderr, "\t-V | --version                    Show version\n");
-	fprintf(stderr, "\t-h | --help                       Show help\n");
+	fprintf(stderr,
+	        "Usage: ksmbd.mountd [-p NUMBER] [-c SMBCONF] [-u PWDDB] [-n[WAY]] [-s]\n"
+	        "       ksmbd.mountd {-V | -h}\n");
 
-	exit(EXIT_FAILURE);
+	if (status != EXIT_SUCCESS)
+		fprintf(stderr, "Try 'ksmbd.mountd --help' for more information.\n");
+	else
+		fprintf(stderr,
+		        "Run ksmbd.mountd user mode and ksmbd kernel mode daemons.\n"
+		        "\n"
+		        "Mandatory arguments to long options are mandatory for short options too.\n"
+		        "  -p, --port=NUMBER       bind to TCP port NUMBER instead of '" STR(KSMBD_CONF_DEFAULT_TCP_PORT) "'\n"
+		        "  -c, --config=SMBCONF    use SMBCONF as config file instead of\n"
+		        "                          '" PATH_SMBCONF "'\n"
+		        "  -u, --users=PWDDB       use PWDDB as user database instead of\n"
+		        "                          '" PATH_PWDDB "'\n"
+		        "  -n, --nodetach[=WAY]    do not detach process from foreground;\n"
+		        "                          WAY is 1 by default;\n"
+		        "                          if WAY is 1 also become process group leader;\n"
+		        "                          if WAY is 0 detach\n"
+		        "  -s, --systemd           run in systemd service mode\n"
+		        "  -V, --version           output version information and exit\n"
+		        "  -h, --help              display this help and exit\n"
+		        "\n"
+		        "ksmbd-tools home page: <https://github.com/cifsd-team/ksmbd-tools>\n");
 }
 
-static void show_version(void)
+static int show_version(void)
 {
 	printf("ksmbd-tools version : %s\n", KSMBD_TOOLS_VERSION);
-	exit(EXIT_FAILURE);
+	return EXIT_SUCCESS;
 }
 
 static int handle_orphaned_lock_file(void)
@@ -556,6 +571,7 @@ static struct option opts[] = {
 
 int main(int argc, char *argv[])
 {
+	int ret = EXIT_FAILURE;
 	int systemd_service = 0;
 	int c;
 
@@ -587,21 +603,32 @@ int main(int argc, char *argv[])
 			systemd_service = 1;
 			break;
 		case 'V':
-			show_version();
-			break;
-		case '?':
+			ret = show_version();
+			goto out;
 		case 'h':
+			ret = EXIT_SUCCESS;
+			/* Fall through */
+		case '?':
 		default:
-			usage();
+			usage(ret);
+			goto out;
 		}
+
+	if (argc > optind) {
+		usage(ret);
+		goto out;
+	}
 
 	if (!global_conf.smbconf || !global_conf.pwddb) {
 		pr_err("Out of memory\n");
-		exit(EXIT_FAILURE);
+		goto out;
 	}
 
 	setup_signals(manager_sig_handler);
 	if (!systemd_service)
-		return manager_process_init();
-	return manager_systemd_service();
+		ret = manager_process_init();
+	else
+		ret = manager_systemd_service();
+out:
+	return ret;
 }


### PR DESCRIPTION
ksmbd-tools: fix typoed macro identifier [duplicate from #243]
ksmbd-tools: fix command-line options
ksmbd-tools: simplify argument handling of ksmbd.mountd
ksmbd-tools: print getopt_long() errors
ksmbd-tools: fix printing of debug component status
ksmbd-tools: improve usage strings and argument handling

Signed-off-by: atheik \<atteh.mailbox@gmail.com>
