### PR TITLE
ksmbd-tools: parse smb.conf in ksmbd.adduser

### DIFF
--- a/addshare/addshare.c
+++ b/addshare/addshare.c
@@ -102,9 +102,7 @@ static int parse_configs(char *smbconf)
 		return ret;
 
 	ret = cp_smbconfig_hash_create(smbconf);
-	if (ret)
-		return ret;
-	return 0;
+	return ret;
 }
 
 static int sanity_check_share_name_simple(char *name)

--- a/adduser/user_admin.c
+++ b/adduser/user_admin.c
@@ -374,9 +374,10 @@ int command_del_user(char *pwddb, char *account)
 	int abort_del_user = 0;
 
 	arg_account = account;
-	if (!cp_key_cmp(global_conf.guest_account, arg_account)) {
-		pr_err("User %s is a global guest account. Abort deletion.\n",
-				arg_account);
+	if (global_conf.guest_account &&
+		!strcmp(global_conf.guest_account, arg_account)) {
+		pr_err("User %s is a global guest account, "
+		       "aborting user deletion\n", arg_account);
 		return -EINVAL;
 	}
 

--- a/mountd/ipc.c
+++ b/mountd/ipc.c
@@ -71,8 +71,8 @@ static int parse_reload_configs(const char *pwddb, const char *smbconf)
 	usm_remove_all_users();
 	ret = cp_parse_pwddb(pwddb);
 	if (ret == -ENOENT) {
-		pr_err("User database file does not exist. %s\n",
-		       "Only guest sessions (if permitted) will work.");
+		pr_info("User database does not exist, "
+			"only guest sessions (if permitted) will work\n");
 	} else if (ret) {
 		pr_err("Unable to parse user database\n");
 		return ret;
@@ -81,7 +81,7 @@ static int parse_reload_configs(const char *pwddb, const char *smbconf)
 	shm_remove_all_shares();
 	ret = cp_parse_reload_smbconf(smbconf);
 	if (ret)
-		pr_err("Unable to parse smb configuration file\n");
+		pr_err("Unable to parse config file\n");
 	return ret;
 }
 

--- a/mountd/mountd.c
+++ b/mountd/mountd.c
@@ -309,19 +309,17 @@ static int parse_configs(char *pwddb, char *smbconf)
 
 	ret = cp_parse_pwddb(pwddb);
 	if (ret == -ENOENT) {
-		pr_err("User database file does not exist. %s\n",
-			"Only guest sessions (if permitted) will work.");
+		pr_info("User database does not exist, "
+			"only guest sessions (if permitted) will work\n");
 	} else if (ret) {
 		pr_err("Unable to parse user database\n");
 		return ret;
 	}
 
 	ret = cp_parse_smbconf(smbconf);
-	if (ret) {
-		pr_err("Unable to parse smb configuration file\n");
-		return ret;
-	}
-	return 0;
+	if (ret)
+		pr_err("Unable to parse config file\n");
+	return ret;
 }
 
 static void worker_process_free(void)


### PR DESCRIPTION
Checking whether a user is a global guest account was broken in
ksmbd.adduser since smb.conf was not parsed. Parse smb.conf also in
ksmbd.adduser. Also, fix detection of the global guest account as in
the bug fixed at commit 7cfd1ad by replacing cp_key_cmp() with
strcmp(). While we're at it, simplify the static parse_configs()
functions and make related logging messages more consistent.

See https://github.com/cifsd-team/ksmbd-tools/pull/250#issuecomment-1166571373.

Signed-off-by: atheik \<atteh.mailbox@gmail.com>