### PR TITLE
ksmbd-tools: rewrite readme

### DIFF
--- a/README
+++ b/README
@@ -1,100 +1,162 @@
-________________________
-BUILDING KSMBD TOOLS
-________________________
+ksmbd-tools is a collection of userspace utilities for the ksmbd kernel server
+merged to mainline in the Linux 5.15 release.
 
-Install preprequisite packages:
-	For Ubuntu:
-	sudo apt-get install autoconf libtool pkg-config libnl-3-dev \
-	libnl-genl-3-dev libglib2.0-dev
+ksmbd-tools home page: https://github.com/cifsd-team/ksmbd-tools
+ksmbd home page: https://www.kernel.org/doc/html/latest/filesystems/cifs/ksmbd.html
 
-	For Fedora, RHEL:
-	sudo yum install autoconf automake libtool glib2-devel libnl3-devel
+## Table of Contents
 
-	For CentOS:
-	sudo yum install glib2-devel libnl3-devel
+- Building and Installing
+- Example Usage
 
-ksmbd-tools.spec should serve as a base template for RPM packagers.
+## Building and Installing
 
-Build steps:
-        - cd into the ksmbd-tools directory
-        - ./autogen.sh
-        - ./configure
-        - make
-        - make install
+You should first check if your distribution already packages ksmbd-tools,
+and if that is the case, consider installing it from the package manager.
+Otherwise, follow these instructions to build it yourself.
+Either the GNU Autotools or Meson build system can be used.
 
-_____________________
-USING KSMBD TOOLS
-_____________________
+Dependencies for Debian and its derivatives:
+--
+git gcc autoconf automake libtool meson libnl-3-dev libnl-genl-3-dev libglib2.0-dev
+--
 
-Setup steps:
-	- install smbd kernel driver
-		modprobe ksmbd
-	- create user/password for SMB share
-		mkdir -p /usr/local/etc/ksmbd/
-		ksmbd.adduser -a <Enter USERNAME for SMB share access>
-		Enter password for SMB share access
-	- create /usr/local/etc/ksmbd/smb.conf file, add SMB share in smb.conf file
-		Refer smb.conf.example
-	- start smbd user space daemon
-		ksmbd.mountd
-	- access share from Windows or Linux using CIFS
+Dependencies for RHEL, its derivatives, and openSUSE:
+--
+git gcc autoconf automake libtool meson libnl3-devel glib2-devel
+--
 
-_____________________
-RESTART KSMBD
-_____________________
+Autotools build:
+--
+git clone https://github.com/cifsd-team/ksmbd-tools.git
+cd ksmbd-tools
+./autogen.sh
+./configure
+make
+sudo make install
+--
 
-steps:
-	- kill user and kernel space daemon
-		sudo ksmbd.control -s
-	- restart user space daemon
-		ksmbd.mountd
+Meson build:
+--
+git clone https://github.com/cifsd-team/ksmbd-tools.git
+cd ksmbd-tools
+mkdir build
+cd build
+meson ..
+ninja
+sudo ninja install
+--
 
-_____________________
-Shutdown KSMBD
-_____________________
+By default, the utilities are in `/usr/local/sbin' and the files they use by
+default are under `/usr/local/etc' in the `ksmbd' directory.
 
-steps:
-	- kill user and kernel space daemon
-		sudo ksmbd.control -s
-	- unload ksmbd module
-		rmmod ksmbd
+If you would like to install ksmbd-tools under `/usr', where it may conflict
+with your distribution's packages, give `--prefix=/usr' and `--sysconfdir=/etc'
+as options to `configure' or `meson'. In that case, the utilities are in
+`/usr/sbin' and the files they use by default are under `/etc' in the `ksmbd`
+directory.
 
+## Example Usage
 
-_____________________
-Enable debug prints
-_____________________
+--
+# if you built and installed ksmbd-tools yourself, by default,
+# the utilities are in `/usr/local/sbin',
+# the default user database is `/usr/local/etc/ksmbd/ksmbdpwd.db', and
+# the default config file is `/usr/local/etc/ksmbd/smb.conf'
+#
+# otherwise, most likely,
+# the utilities are in `/usr/sbin',
+# the default user database is `/etc/ksmbd/ksmbdpwd.db', and
+# the default config file is `/etc/ksmbd/smb.conf'
 
-steps:
-	- Enable all component prints
-		sudo ksmbd.control -d "all"
-	- Enable one of components(smb, auth, vfs, oplock, ipc, conn, rdma)
-		sudo ksmbd.control -d "smb"
-	- Disable prints:
-		If you try the selected component once more, It is disabled without brackets.
+# add a share (case insensitive) to the default config file
+# `--options' takes a single argument, so quote it accordingly in your shell
+# note that the shell expands `$HOME' here, `ksmbd.addshare' will never do it
+# newline is the only safe character to use as an option separator
+sudo ksmbd.addshare --add-share=MyShare --options="
+path = $HOME/MyShare
+read only = no
+"
 
+# create the share path directory
+# the share stores files in this directory using its underlying filesystem
+mkdir -vp $HOME/MyShare
 
---------------------
-ADMIN TOOLS
---------------------
+# the default config file now looks like this:
+#
+# [myshare]
+#         path = /home/tester/MyShare
+#         read only = no
+#
+# the `[global]' section contains options that are not share specific
+# you can set the default options for all shares by adding them to `[global]'
+# `ksmbd.addshare` cannot edit `[global]', so do it with a text editor
+# see `Documentation/configuration.txt' for more details
 
-- ksmbd.adduser
-	Adds, updates or removes (-a/-u/-d) a user from ksmbd pwd file.
+# add a user to the default user database
+# you will be prompted for a password
+sudo ksmbd.adduser --add-user=MyUser
 
-- ksmbd.addshare
-	Adds, updates or removes (-a/-u/-d) a net share from smb.conf file.
+# there is no system user called `MyUser' so it has to be mapped to one
+# `map to guest = bad user' in `[global]' would mean map to `nobody' by default
+# or, we can force all users accessing the share to map to a system user and group
 
-Usage example:
+# update the options of a share in the default config file
+sudo ksmbd.addshare --update-share=MyShare --options="
+force user = $USER
+force group = $USER
+"
 
-Creating a new share:
+# the default config file now looks like this:
+#
+# [myshare]
+#         force user = tester
+#         path = /home/tester/MyShare
+#         force group = tester
+#         read only = no
+#
 
-ksmbd.addshare -a files -o "\
-		     path=/home/users/files \
-		     comment=exported files \
-		     writeable=yes \
-		     read only = no \
-		     "
+# load the kernel module if it is not already loaded
+sudo modprobe ksmbd
 
-Note that share options (-o) must always be enquoted ("...").
+# run the user mode and kernel mode daemons
+# all interfaces are listened to by default
+sudo ksmbd.mountd
 
-ksmbd.addshare tool does not modify [global] smb.conf section; only net
-share configs are supported at the moment.
+# mount the new share with cifs-utils and authenticate as the new user
+# you will be prompted for a password
+sudo mount -o user=MyUser //127.0.0.1/MyShare /mnt
+
+# you can now access the share at `/mnt'
+sudo touch /mnt/hello_from_cifs_utils
+
+# unmount the share
+sudo umount /mnt
+
+# update the password of a user in the default user database
+# `--password' can be used to give the password instead of prompting
+sudo ksmbd.adduser --update-user=MyUser --password=MyNewPassword
+
+# authenticating with the new password will *not* work unless ksmbd is restarted
+sudo mount -o user=MyUser,pass=MyNewPassword //127.0.0.1/MyShare /mnt
+
+# delete a user from the default user database
+sudo ksmbd.adduser --del-user=MyUser
+
+# authenticating as the deleted user *will* work until ksmbd is restarted
+sudo mount -o user=MyUser //127.0.0.1/MyShare /mnt
+sudo umount /mnt
+
+# this need to restart when updating and deleting users applies to shares as well
+# however, adding new users and shares does not require a restart
+# restarting ksmbd means you run `ksmbd.mountd' again after you shut it down.
+
+# toggle printing of the `all' debug component
+sudo ksmbd.control --debug=all
+
+# shutdown the user and kernel mode daemons
+sudo ksmbd.control --shutdown
+
+# remove the kernel module
+sudo rmmod ksmbd
+--


### PR DESCRIPTION
The plain text README and its Markdown version README.md were
inconsistent and outdated. There was a reference to users.db instead
of ksmbdpwd.db and the example share options argument created a
malformed smb.conf. Since the usage strings are now more complete as
of commit 47d93fc, repurpose the README files to give an example usage
session which setups a share and a user, briefly introduces smb.conf,
and shows an example about the current limitation of updating and
deleting users and shares.

The new Markdown version of README.md:
https://github.com/atheik/ksmbd-tools/tree/rewrite-readme#readme

If this is too different to the previous READMEs then let me know.

Signed-off-by: atheik \<atteh.mailbox@gmail.com>