### PR TITLE
ksmbd-tools: add missing printf attributes

### DIFF
--- a/include/ksmbdtools.h
+++ b/include/ksmbdtools.h
@@ -123,7 +123,7 @@ static int log_level = PR_INFO;
  */
 char *strerr(int err);
 
-__attribute__ ((format (printf, 2, 3)))
+G_GNUC_PRINTF(2, 3)
 extern void __pr_log(int level, const char *fmt, ...);
 extern void set_logger_app_name(const char *an);
 extern const char *get_logger_app_name(void);

--- a/include/management/spnego.h
+++ b/include/management/spnego.h
@@ -24,9 +24,9 @@ void spnego_destroy(void);
 int spnego_handle_authen_request(struct ksmbd_spnego_authen_request *req,
 				struct ksmbd_spnego_auth_out *auth_out);
 #else
-static int spnego_init(void) { return 0; }
-static void spnego_destroy(void) {}
-static int spnego_handle_authen_request(struct ksmbd_spnego_authen_request *req,
+static inline int spnego_init(void) { return 0; }
+static inline void spnego_destroy(void) {}
+static inline int spnego_handle_authen_request(struct ksmbd_spnego_authen_request *req,
 				struct ksmbd_spnego_auth_out *auth_out)
 {
 	return -ENOTSUP;

--- a/lib/ksmbdtools.c
+++ b/lib/ksmbdtools.c
@@ -40,6 +40,7 @@ static int syslog_level(int level)
 	return LOG_ERR;
 }
 
+G_GNUC_PRINTF(2, 0)
 static void __pr_log_stdio(int level, const char *fmt, va_list list)
 {
 	char buf[1024];
@@ -48,6 +49,7 @@ static void __pr_log_stdio(int level, const char *fmt, va_list list)
 	printf("%s", buf);
 }
 
+G_GNUC_PRINTF(2, 0)
 static void __pr_log_syslog(int level, const char *fmt, va_list list)
 {
 	vsyslog(syslog_level(level), fmt, list);

--- a/mountd/smbacl.c
+++ b/mountd/smbacl.c
@@ -43,6 +43,7 @@ int smb_read_sid(struct ksmbd_dcerpc *dce, struct smb_sid *sid)
 	for (i = 0; i < sid->num_subauth; ++i)
 		if (ndr_read_int32(dce, &sid->sub_auth[i]))
 			return -EINVAL;
+	return 0;
 }
 
 void smb_write_sid(struct ksmbd_dcerpc *dce, const struct smb_sid *src)


### PR DESCRIPTION
clang warns about these with -Wformat=2 but gcc does not.

Signed-off-by: Rosen Penev <rosenp@gmail.com>