### PR TITLE
ksmbd-tools: clarify options format of ksmbd.addshare in usage string

### DIFF
--- a/addshare/addshare.c
+++ b/addshare/addshare.c
@@ -43,7 +43,7 @@ static void usage(int status)
 		"       ksmbd.addshare {-V | -h}\n");
 
 	if (status != EXIT_SUCCESS)
-		g_printerr("Try 'ksmbd.addshare --help' for more information.\n");
+		g_printerr("Try `ksmbd.addshare --help' for more information.\n");
 	else {
 		g_printerr(
 			"Configure shares for config file of ksmbd.mountd user mode daemon.\n"
@@ -51,22 +51,24 @@ static void usage(int status)
 			"Mandatory arguments to long options are mandatory for short options too.\n"
 			"  -a, --add-share=SHARE       add SHARE to config file;\n"
 			"                              SHARE is 1 to " STR(KSMBD_REQ_MAX_SHARE_NAME) " characters;\n"
-			"                              SHARE cannot be 'global';\n"
-			"                              you must also give option 'options'\n"
+			"                              SHARE cannot be `global';\n"
+			"                              you must also give option `options'\n"
 			"  -d, --del-share=SHARE       delete SHARE from config file;\n"
 			"                              you must restart ksmbd for changes to take effect\n"
 			"  -u, --update-share=SHARE    update SHARE in config file;\n"
-			"                              you must also give option 'options';\n"
+			"                              you must also give option `options';\n"
 			"                              you must restart ksmbd for changes to take effect\n"
 			"  -o, --options=OPTIONS       provide OPTIONS for share;\n"
-			"                              OPTIONS has format 'key1=val1 key2=val2'\n"
+			"                              OPTIONS is one argument and has format\n"
+			"                              `1st op = 1st val<newline>2nd op = 2nd val...';\n"
+			"                              separators other than newline create ambiguity\n"
 			"  -c, --config=SMBCONF        use SMBCONF as config file instead of\n"
-			"                              '" PATH_SMBCONF "'\n"
+			"                              `" PATH_SMBCONF "'\n"
 			"  -v, --verbose               be more verbose; unimplemented\n"
 			"  -V, --version               output version information and exit\n"
 			"  -h, --help                  display this help and exit\n"
 			"\n"
-			"The following OPTIONS are supported:\n");
+			"Following options are supported for use in OPTIONS:\n");
 		for (i = 0; i < KSMBD_SHARE_CONF_MAX; i++)
 			g_printerr("  %s\n", KSMBD_SHARE_CONF[i]);
 		g_printerr(

--- a/adduser/adduser.c
+++ b/adduser/adduser.c
@@ -42,7 +42,7 @@ static void usage(int status)
 		"       ksmbd.adduser {-V | -h}\n");
 
 	if (status != EXIT_SUCCESS)
-		g_printerr("Try 'ksmbd.adduser --help' for more information.\n");
+		g_printerr("Try `ksmbd.adduser --help' for more information.\n");
 	else
 		g_printerr(
 			"Configure users for user database of ksmbd.mountd user mode daemon.\n"
@@ -50,20 +50,20 @@ static void usage(int status)
 			"Mandatory arguments to long options are mandatory for short options too.\n"
 			"  -a, --add-user=USER         add USER to user database;\n"
 			"                              USER is 1 to " STR(KSMBD_REQ_MAX_ACCOUNT_NAME_SZ) " characters;\n"
-			"                              USER cannot contain ':' or '\\n';\n"
-			"                              USER cannot be 'root'\n"
+			"                              USER cannot contain `:' or newline;\n"
+			"                              USER cannot be `root'\n"
 			"  -d, --del-user=USER         delete USER from user database;\n"
 			"                              you must restart ksmbd for changes to take effect\n"
 			"  -u, --update-user=USER      update USER in user database;\n"
 			"                              you must restart ksmbd for changes to take effect\n"
 			"  -p, --password=PWD          provide PWD for user;\n"
 			"                              PWD is 0 to " STR(MAX_NT_PWD_LEN) " characters;\n"
-			"                              PWD cannot contain '\\n'\n"
+			"                              PWD cannot contain newline\n"
 			"  -i, --import-users=PWDDB    use PWDDB as user database instead of\n"
-			"                              '" PATH_PWDDB "';\n"
+			"                              `" PATH_PWDDB "';\n"
 			"                              this option does nothing by itself\n"
 			"  -c, --config=SMBCONF        use SMBCONF as config file instead of\n"
-			"                              '" PATH_SMBCONF "'\n"
+			"                              `" PATH_SMBCONF "'\n"
 			"  -v, --verbose               be more verbose; unimplemented\n"
 			"  -V, --version               output version information and exit\n"
 			"  -h, --help                  display this help and exit\n"

--- a/control/control.c
+++ b/control/control.c
@@ -17,7 +17,7 @@ static void usage(int status)
 	g_printerr("Usage: ksmbd.control {-s | -d COMPONENT | -c | -V | -h}\n");
 
 	if (status != EXIT_SUCCESS)
-		g_printerr("Try 'ksmbd.control --help' for more information.\n");
+		g_printerr("Try `ksmbd.control --help' for more information.\n");
 	else
 		g_printerr(
 			"Control ksmbd.mountd user mode and ksmbd kernel mode daemons.\n"
@@ -25,8 +25,8 @@ static void usage(int status)
 			"Mandatory arguments to long options are mandatory for short options too.\n"
 			"  -s, --shutdown           shutdown ksmbd.mountd and ksmbd and exit\n"
 			"  -d, --debug=COMPONENT    toggle debug printing for COMPONENT and exit;\n"
-			"                           COMPONENT is 'all', 'smb', 'auth', 'vfs',\n"
-			"                           'oplock', 'ipc', 'conn', or 'rdma';\n"
+			"                           COMPONENT is `all', `smb', `auth', `vfs',\n"
+			"                           `oplock', `ipc', `conn', or `rdma';\n"
 			"                           output also status of all components;\n"
 			"                           enabled components are enclosed in brackets\n"
 			"  -c, --ksmbd-version      output ksmbd version information and exit\n"

--- a/mountd/mountd.c
+++ b/mountd/mountd.c
@@ -46,17 +46,17 @@ static void usage(int status)
 		"       ksmbd.mountd {-V | -h}\n");
 
 	if (status != EXIT_SUCCESS)
-		g_printerr("Try 'ksmbd.mountd --help' for more information.\n");
+		g_printerr("Try `ksmbd.mountd --help' for more information.\n");
 	else
 		g_printerr(
 			"Run ksmbd.mountd user mode and ksmbd kernel mode daemons.\n"
 			"\n"
 			"Mandatory arguments to long options are mandatory for short options too.\n"
-			"  -p, --port=NUMBER       bind to TCP port NUMBER instead of '" STR(KSMBD_CONF_DEFAULT_TCP_PORT) "'\n"
+			"  -p, --port=NUMBER       bind to TCP port NUMBER instead of " STR(KSMBD_CONF_DEFAULT_TCP_PORT) "\n"
 			"  -c, --config=SMBCONF    use SMBCONF as config file instead of\n"
-			"                          '" PATH_SMBCONF "'\n"
+			"                          `" PATH_SMBCONF "'\n"
 			"  -u, --users=PWDDB       use PWDDB as user database instead of\n"
-			"                          '" PATH_PWDDB "'\n"
+			"                          `" PATH_PWDDB "'\n"
 			"  -n, --nodetach[=WAY]    do not detach process from foreground;\n"
 			"                          WAY is 1 by default;\n"
 			"                          if WAY is 1 also become process group leader;\n"


### PR DESCRIPTION
The only safe character for separating options in the `options` option
of ksmbd.addshare is the newline. Update the usage string to reflect
this. While we're at it, make the quoting for the usage strings follow
a more readable convention.

Signed-off-by: atheik \<atteh.mailbox@gmail.com>