### PR TITLE
Fix detection of the ipc share name

### DIFF
--- a/addshare/addshare.c
+++ b/addshare/addshare.c
@@ -107,7 +107,7 @@ static int parse_configs(char *smbconf)
 
 static int sanity_check_share_name_simple(char *name)
 {
-	int sz, i;
+	int sz;
 
 	if (!name)
 		return -EINVAL;

--- a/adduser/adduser.c
+++ b/adduser/adduser.c
@@ -111,7 +111,7 @@ static int parse_configs(char *pwddb, char *smbconf)
 
 static int sanity_check_user_name_simple(char *uname)
 {
-	int sz, i;
+	int sz;
 
 	if (!uname)
 		return -EINVAL;

--- a/lib/config_parser.c
+++ b/lib/config_parser.c
@@ -624,7 +624,7 @@ static void groups_callback(gpointer _k, gpointer _v, gpointer user_data)
 	struct smbconf_group *group = (struct smbconf_group *)_v;
 
 	if (group != global_group) {
-		if (global_group && g_ascii_strncasecmp(_k, "ipc$", 4))
+		if (global_group && g_ascii_strcasecmp(_k, "ipc$"))
 			g_hash_table_foreach(global_group->kv,
 					     append_key_value,
 					     group->kv);

--- a/lib/management/share.c
+++ b/lib/management/share.c
@@ -602,7 +602,7 @@ static void init_share_from_group(struct ksmbd_share *share,
 	set_share_flag(share, KSMBD_SHARE_FLAG_OPLOCKS);
 	set_share_flag(share, KSMBD_SHARE_FLAG_STORE_DOS_ATTRS);
 
-	if (!cp_key_cmp(share->name, "IPC$"))
+	if (!g_ascii_strcasecmp(share->name, "ipc$"))
 		set_share_flag(share, KSMBD_SHARE_FLAG_PIPE);
 
 	g_hash_table_foreach(group->kv, process_group_kv, share);

--- a/mountd/mountd.c
+++ b/mountd/mountd.c
@@ -123,8 +123,10 @@ retry:
 		return -EINVAL;
 
 	sz = snprintf(manager_pid, sizeof(manager_pid), "%d", getpid());
-	if (write(lock_fd, manager_pid, sz) == -1)
+	if (write(lock_fd, manager_pid, sz) == -1) {
 		pr_err("Unable to record main PID: %m\n");
+		return -EINVAL;
+	}
 	return 0;
 }
 
@@ -135,7 +137,7 @@ retry:
  */
 static int write_file_safe(char *path, char *buff, size_t length, int mode)
 {
-	int fd, ret = -1;
+	int fd, ret = -EINVAL;
 	char *path_tmp = g_strdup_printf("%s.tmp", path);
 
 	if (g_file_test(path_tmp, G_FILE_TEST_EXISTS))


### PR DESCRIPTION
ksmbd-tools: fix detection of the ipc share name
ksmbd-tools: remove unused variables
ksmbd-tools: return negated errno on lock file write error

The bug fixed in `ksmbd-tools: fix detection of the ipc share name` was discussed at https://github.com/cifsd-team/ksmbd-tools/pull/250#issuecomment-1194753509.

The bug fixed in `ksmbd-tools: return negated errno on lock file write error` was discussed at https://github.com/cifsd-team/ksmbd-tools/pull/264#issuecomment-1193220719.

Signed-off-by: atheik \<atteh.mailbox@gmail.com>