### PR TITLE
ksmbd-tools: fix readonly flagging in tree connect request handler

### DIFF
--- a/lib/management/tree_conn.c
+++ b/lib/management/tree_conn.c
@@ -72,7 +72,7 @@ int tcm_handle_tree_connect(struct ksmbd_tree_connect_request *req,
 	if (test_share_flag(share, KSMBD_SHARE_FLAG_WRITEABLE))
 		set_conn_flag(conn, KSMBD_TREE_CONN_FLAG_WRITABLE);
 	if (test_share_flag(share, KSMBD_SHARE_FLAG_READONLY))
-		set_conn_flag(conn, KSMBD_SHARE_FLAG_READONLY);
+		set_conn_flag(conn, KSMBD_TREE_CONN_FLAG_READ_ONLY);
 
 	if (shm_open_connection(share)) {
 		resp->status = KSMBD_TREE_CONN_STATUS_TOO_MANY_CONNS;


### PR DESCRIPTION
When handling a tree connect request, if the share is flagged
with KSMBD_SHARE_FLAG_READONLY, the connection gets erroneously flagged
with KSMBD_SHARE_FLAG_READONLY. Effectively, the connection gets
flagged with KSMBD_TREE_CONN_FLAG_ADMIN_ACCOUNT since it has the same
value as the share flag. Fix this by using the proper connection flag.

Signed-off-by: atheik \<atteh.mailbox@gmail.com>