### PR TITLE
Implement setting debug log level per utility

### DIFF
--- a/control/control.c
+++ b/control/control.c
@@ -14,7 +14,9 @@
 
 static void usage(int status)
 {
-	g_printerr("Usage: ksmbd.control {-s | -r | -d COMPONENT | -c | -V | -h}\n");
+	g_printerr(
+		"Usage: ksmbd.control {-s | -r | -d COMPONENT | -c} [-v]\n"
+		"       ksmbd.control {-V | -h}\n");
 
 	if (status != EXIT_SUCCESS)
 		g_printerr("Try `ksmbd.control --help' for more information.\n");
@@ -31,6 +33,7 @@ static void usage(int status)
 			"                           output also status of all components;\n"
 			"                           enabled components are enclosed in brackets\n"
 			"  -c, --ksmbd-version      output ksmbd version information and exit\n"
+			"  -v, --verbose            be verbose\n"
 			"  -V, --version            output version information and exit\n"
 			"  -h, --help               display this help and exit\n"
 			"\n"
@@ -42,6 +45,7 @@ static const struct option opts[] = {
 	{"reload",		no_argument,		NULL,	'r' },
 	{"debug",		required_argument,	NULL,	'd' },
 	{"ksmbd-version",	no_argument,		NULL,	'c' },
+	{"verbose",		no_argument,		NULL,	'v' },
 	{"version",		no_argument,		NULL,	'V' },
 	{"help",		no_argument,		NULL,	'h' },
 	{NULL,			0,			NULL,	 0  }
@@ -141,7 +145,7 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	while ((c = getopt_long(argc, argv, "srd:cVh", opts, NULL)) != EOF)
+	while ((c = getopt_long(argc, argv, "srd:cvVh", opts, NULL)) != EOF)
 		switch (c) {
 		case 's':
 			ret = ksmbd_control_shutdown();
@@ -155,6 +159,9 @@ int main(int argc, char *argv[])
 		case 'c':
 			ret = ksmbd_control_show_version();
 			goto out;
+		case 'v':
+			set_log_level(PR_DEBUG);
+			break;
 		case 'V':
 			ret = show_version();
 			goto out;

--- a/include/ksmbdtools.h
+++ b/include/ksmbdtools.h
@@ -108,11 +108,12 @@ extern int ksmbd_health_status;
 #define PRINF		LOGAPP" INFO: "
 #define PRDEBUG		LOGAPP" DEBUG: "
 
-#define PR_ERROR	0
-#define PR_INFO		1
-#define PR_DEBUG	2
+#define PR_NONE		0
+#define PR_ERROR	1
+#define PR_INFO		2
+#define PR_DEBUG	3
 
-static int log_level = PR_INFO;
+extern int log_level;
 
 #define PR_LOGGER_STDIO         0
 #define PR_LOGGER_SYSLOG        1
@@ -122,6 +123,7 @@ extern void __pr_log(int level, const char *fmt, ...);
 extern void set_logger_app_name(const char *an);
 extern const char *get_logger_app_name(void);
 extern void pr_logger_init(int flags);
+extern int set_log_level(int level);
 
 #define pr_log(l, f, ...)						\
 	do {								\

--- a/lib/ksmbdtools.c
+++ b/lib/ksmbdtools.c
@@ -14,6 +14,9 @@
 #include <stdio.h>
 #include <ksmbdtools.h>
 
+int log_level = PR_INFO;
+int ksmbd_health_status;
+
 static const char *app_name = "unknown";
 static int log_open;
 
@@ -87,6 +90,18 @@ void pr_logger_init(int flag)
 		__logger = __pr_log_syslog;
 		log_open = 1;
 	}
+}
+
+int set_log_level(int level)
+{
+	int old_level;
+
+	if (log_level == PR_DEBUG)
+		return log_level;
+
+	old_level = log_level;
+	log_level = level;
+	return old_level;
 }
 
 #if TRACING_DUMP_NL_MSG

--- a/lib/management/share.c
+++ b/lib/management/share.c
@@ -101,7 +101,7 @@ static void kill_ksmbd_share(struct ksmbd_share *share)
 {
 	int i;
 
-	pr_debug("Kill share %s\n", share->name);
+	pr_debug("Kill share `%s'\n", share->name);
 
 	for (i = 0; i < KSMBD_SHARE_USERS_MAX; i++)
 		free_user_map(share->maps[i]);
@@ -636,6 +636,7 @@ int shm_add_new_share(struct smbconf_group *group)
 		return 0;
 	}
 
+	pr_debug("New share `%s'\n", share->name);
 	if (!g_hash_table_insert(shares_table, share->name, share)) {
 		kill_ksmbd_share(share);
 		ret = -EINVAL;

--- a/lib/management/user.c
+++ b/lib/management/user.c
@@ -20,7 +20,7 @@ static GRWLock		users_table_lock;
 
 static void kill_ksmbd_user(struct ksmbd_user *user)
 {
-	pr_debug("Kill user %s\n", user->name);
+	pr_debug("Kill user `%s'\n", user->name);
 
 	free(user->name);
 	free(user->pass_b64);
@@ -188,6 +188,7 @@ int usm_add_new_user(char *name, char *pwd)
 		return 0;
 	}
 
+	pr_debug("New user `%s'\n", user->name);
 	if (!g_hash_table_insert(users_table, user->name, user)) {
 		kill_ksmbd_user(user);
 		ret = -EINVAL;

--- a/mountd/ipc.c
+++ b/mountd/ipc.c
@@ -65,14 +65,18 @@ static int generic_event(int type, void *payload, size_t sz)
 
 static int parse_reload_configs(const char *pwddb, const char *smbconf)
 {
-	int ret;
+	int ret, old_level;
 
 	pr_debug("Reload config\n");
+
 	usm_remove_all_users();
+	old_level = set_log_level(PR_NONE);
 	ret = cp_parse_pwddb(pwddb);
+	set_log_level(old_level);
 	if (ret == -ENOENT) {
-		pr_info("User database does not exist, "
-			"only guest sessions (if permitted) will work\n");
+		pr_info("User database `%s' does not exist; "
+			"only guest sessions may work\n",
+			pwddb);
 	} else if (ret) {
 		pr_err("Unable to parse user database\n");
 		return ret;


### PR DESCRIPTION
ksmbd-tools: implement setting debug log level per utility
ksmbd-tools: remove getuid() check from control
ksmbd-tools: check errno only after waitpid() failure

See https://github.com/cifsd-team/ksmbd-tools/pull/271#issuecomment-1214161793 and onwards.

Signed-off-by: atheik \<atteh.mailbox@gmail.com>