### PR TITLE
ksmbd-tools: set netlink socket's receive buffer size to 1 MiB

### DIFF
--- a/include/ipc.h
+++ b/include/ipc.h
@@ -14,6 +14,12 @@
  */
 #define KSMBD_IPC_MAX_MESSAGE_SIZE	(16 * 1024)
 
+/*
+ * The netlink socket's receive buffer size needs to be increased
+ * to avoid -ENOBUFS errors when receiving.
+ */
+#define KSMBD_IPC_SO_RCVBUF_SIZE	(1 * 1024 * 1024)
+
 struct ksmbd_ipc_msg {
 	unsigned int	type;
 	unsigned int	sz;

--- a/mountd/ipc.c
+++ b/mountd/ipc.c
@@ -495,6 +495,12 @@ int ipc_init(void)
 		goto out_error;
 	}
 
+	ret = nl_socket_set_buffer_size(sk, KSMBD_IPC_SO_RCVBUF_SIZE, 0);
+	if (ret) {
+		pr_err("Cannot set netlink socket buffer size: %s [%d]\n", nl_geterror(ret), ret);
+		goto out_error;
+	}
+
 	if (genl_register_family(&ksmbd_family_ops)) {
 		pr_err("Cannot register netlink family\n");
 		goto out_error;


### PR DESCRIPTION
Fixes https://github.com/cifsd-team/ksmbd-tools/issues/235.