### PR TITLE
ksmbd-tools: make @group works in ksmbd.conf

### DIFF
--- a/include/config_parser.h
+++ b/include/config_parser.h
@@ -45,5 +45,7 @@ unsigned long cp_get_group_kv_long(char *v);
 int cp_get_group_kv_config_opt(char *v);
 char **cp_get_group_kv_list(char *v);
 void cp_group_kv_list_free(char **list);
+void cp_insert_user(char *name, GHashTable *map);
+void cp_insert_user_group(char *gname, GHashTable *map);
 
 #endif /* __KSMBD_CONFIG_H__ */

--- a/lib/management/share.c
+++ b/lib/management/share.c
@@ -269,26 +269,18 @@ static GHashTable *parse_list(GHashTable *map, char **list)
 		return map;
 
 	for (i = 0;  list[i] != NULL; i++) {
-		struct ksmbd_user *user;
 		char *p = list[i];
 
 		p = cp_ltrim(p);
 		if (!p)
 			continue;
 
-		user = usm_lookup_user(p);
-		if (!user) {
-			pr_info("Drop non-existing user `%s'\n", p);
+		if (*p=='@') {
+			cp_insert_user_group(p+1, map);
 			continue;
 		}
 
-		if (g_hash_table_lookup(map, user->name)) {
-			pr_debug("User `%s' already exists in a map\n",
-				 user->name);
-			continue;
-		}
-
-		g_hash_table_insert(map, user->name, user);
+		cp_insert_user(p, map);
 	}
 
 	cp_group_kv_list_free(list);


### PR DESCRIPTION
This commit add the feature that you can use "@groupname" in valid users/invalid users/read list/write list/admin users in ksmbd.conf when you want to add all users in this group, as samba do in smb.conf.

To reach this, some codes moved form parse_list() to cp_insert_user(), and a new function cp_insert_user_group() was added.
cp_insert_user_group() scans the file "/etc/group" to find the user list of the group, and than calls cp_insert_user() for each of those users.

After those changes, parse_list() now can correctly deal with "@groupname", not trying to add a user named "@groupname". 

Signed-off-by: Wang Junjie <iamwudy@qq.com>