### PR TITLE
meson: run through muon analyze

### DIFF
--- a/addshare/meson.build
+++ b/addshare/meson.build
@@ -1,4 +1,4 @@
-addshare = executable(
+executable(
   'ksmbd.addshare',
   'share_admin.c',
   'addshare.c',

--- a/adduser/meson.build
+++ b/adduser/meson.build
@@ -1,4 +1,4 @@
-adduser = executable(
+executable(
   'ksmbd.adduser',
   'md4_hash.c',
   'user_admin.c',

--- a/control/meson.build
+++ b/control/meson.build
@@ -1,4 +1,4 @@
-control = executable(
+executable(
   'ksmbd.control',
   'control.c',
   dependencies: [

--- a/meson.build
+++ b/meson.build
@@ -13,10 +13,10 @@ exec awk '/define KSMBD_TOOLS_VERSION / { gsub(/"/,"",$3); printf "%s", $3 }' in
   meson_version: '>= 0.51.0',
 )
 
-tools_incdir = include_directories([
+tools_incdir = include_directories(
   '.',
   'include',
-])
+)
 
 glib_dep = dependency(
   'glib-2.0',

--- a/mountd/meson.build
+++ b/mountd/meson.build
@@ -1,4 +1,4 @@
-mountd = executable(
+executable(
   'ksmbd.mountd',
   'worker.c',
   'ipc.c',


### PR DESCRIPTION
Mostly unused variable removals. Removed pointless [] in include_directories.

Removed excess ''' in run_command to make compatible with muon.

Signed-off-by: Rosen Penev <rosenp@gmail.com>