### PR TITLE
ksmbd-tools: fix host lookup leak in srvsvc_share_get_info_invoke()

### DIFF
--- a/mountd/rpc_srvsvc.c
+++ b/mountd/rpc_srvsvc.c
@@ -186,15 +186,11 @@ static int srvsvc_share_get_info_invoke(struct ksmbd_rpc_pipe *pipe,
 		put_ksmbd_share(share);
 		return 0;
 	}
-
-	if (ret != 0) {
-		gchar *server_name = g_ascii_strdown(STR_VAL(hdr->server_name),
-				strlen(STR_VAL(hdr->server_name)));
-
+	if (ret) {
 		ret = shm_lookup_hosts_map(share,
 					   KSMBD_SHARE_HOSTS_DENY_MAP,
-					   server_name);
-		if (ret == 0) {
+					   STR_VAL(hdr->server_name));
+		if (!ret) {
 			put_ksmbd_share(share);
 			return 0;
 		}


### PR DESCRIPTION
Before doing a host lookup in srvsvc_share_get_info_invoke(), the host name is converted to ASCII lowercase through g_ascii_strdown(). This is unneeded since host lookup does not work. When share->hosts_allow_map and share->hosts_deny_map are non-NULL, they are always empty since parse_list() only supports lists of users. Additionally, the allocation done by g_ascii_strdown() is leaked. Remove the lowercase conversion. If host lookup should work in the future, ASCII lowercase conversion can be done at lookup time.

Signed-off-by: Atte Heikkilä \<atteh.mailbox@gmail.com>