### PR TITLE
ksmbd-tools: make user removal case sensitive in adduser

### DIFF
--- a/adduser/user_admin.c
+++ b/adduser/user_admin.c
@@ -277,7 +277,7 @@ static void write_remove_user_cb(gpointer key,
 	struct ksmbd_user *user = (struct ksmbd_user *)value;
 	char **account = (char **)user_data;
 
-	if (!g_ascii_strcasecmp(user->name, *account)) {
+	if (!strcmp(user->name, *account)) {
 		pr_info("User `%s' removed\n", user->name);
 		return;
 	}


### PR DESCRIPTION
User names are not ASCII case-insensitive but they are treated as such by adduser during user deletion. Check for the user name to be deleted with strcmp() rather than g_ascii_strcasecmp().

Signed-off-by: Atte Heikkilä \<atteh.mailbox@gmail.com>