### PR TITLE
ksmbd-tools: fix unused variable value

### DIFF
--- a/tools/config_parser.c
+++ b/tools/config_parser.c
@@ -639,7 +639,7 @@ static void groups_callback(gpointer _k, gpointer _v, gpointer user_data)
 static int cp_add_ipc_group(void)
 {
 	char *comment = NULL, *guest = NULL;
-	int ret = 0;
+	int ret;
 
 	ipc_group = g_hash_table_lookup(parser.groups, "ipc$");
 	if (ipc_group)


### PR DESCRIPTION
ret is default initialized to 0.

Signed-off-by: Rosen Penev <rosenp@gmail.com>