### PR TITLE
some g_autofree conversions

### DIFF
--- a/mountd/rpc.c
+++ b/mountd/rpc.c
@@ -422,7 +422,7 @@ static gchar *ndr_convert_char_to_unicode(struct ksmbd_dcerpc *dce, char *str,
 
 int ndr_write_vstring(struct ksmbd_dcerpc *dce, void *value)
 {
-	gchar *out;
+	g_autofree char *out = NULL;
 	gsize bytes_written = 0;
 
 	size_t raw_len, str_len;
@@ -456,13 +456,12 @@ int ndr_write_vstring(struct ksmbd_dcerpc *dce, void *value)
 	ret |= ndr_write_bytes(dce, out, bytes_written);
 	auto_align_offset(dce);
 
-	g_free(out);
 	return ret;
 }
 
 int ndr_write_string(struct ksmbd_dcerpc *dce, char *str)
 {
-	gchar *out;
+	g_autofree char *out = NULL;
 	gsize bytes_written = 0;
 
 	size_t len;
@@ -482,13 +481,12 @@ int ndr_write_string(struct ksmbd_dcerpc *dce, char *str)
 	ret |= ndr_write_bytes(dce, out, bytes_written);
 	auto_align_offset(dce);
 
-	g_free(out);
 	return ret;
 }
 
 int ndr_write_lsa_string(struct ksmbd_dcerpc *dce, char *str)
 {
-	gchar *out;
+	g_autofree char *out = NULL;
 	gsize bytes_written = 0;
 
 	size_t len;
@@ -508,7 +506,6 @@ int ndr_write_lsa_string(struct ksmbd_dcerpc *dce, char *str)
 	ret |= ndr_write_bytes(dce, out, bytes_written);
 	auto_align_offset(dce);
 
-	g_free(out);
 	return ret;
 }
 

--- a/mountd/rpc_samr.c
+++ b/mountd/rpc_samr.c
@@ -366,7 +366,8 @@ static int samr_query_user_info_return(struct ksmbd_rpc_pipe *pipe)
 {
 	struct ksmbd_dcerpc *dce = pipe->dce;
 	struct connect_handle *ch;
-	char *home_dir, *profile_path;
+	char *home_dir;
+	g_autofree char *profile_path = NULL;
 	char hostname[NAME_MAX];
 	int home_dir_len, i;
 
@@ -509,7 +510,6 @@ static int samr_query_user_info_return(struct ksmbd_rpc_pipe *pipe)
 		ndr_write_int8(dce, 0xff);
 
 	g_free(home_dir);
-	g_free(profile_path);
 	return KSMBD_RPC_OK;
 }
 

--- a/mountd/smbacl.c
+++ b/mountd/smbacl.c
@@ -151,7 +151,7 @@ int set_domain_name(struct smb_sid *sid, char *domain, int *type)
 {
 	int ret = 0;
 	char domain_string[NAME_MAX] = {0};
-	gchar *domain_name;
+	g_autofree char *domain_name = NULL;
 
 	if (!smb_compare_sids(sid, &sid_domain) &&
 	    !memcmp(&sid->sub_auth[1], global_conf.gen_subauth,
@@ -162,7 +162,6 @@ int set_domain_name(struct smb_sid *sid, char *domain, int *type)
 		if (!domain_name)
 			return -ENOMEM;
 		strcpy(domain, domain_name);
-		g_free(domain_name);
 		*type = SID_TYPE_USER;
 	} else if (!smb_compare_sids(sid, &sid_unix_users)) {
 		strcpy(domain, "Unix User");
@@ -177,7 +176,6 @@ int set_domain_name(struct smb_sid *sid, char *domain, int *type)
 		if (!domain_name)
 			return -ENOMEM;
 		strcpy(domain, domain_name);
-		g_free(domain_name);
 		*type = SID_TYPE_UNKNOWN;
 		ret = -ENOENT;
 	}

--- a/tools/management/share.c
+++ b/tools/management/share.c
@@ -229,42 +229,26 @@ void shm_destroy(void)
 
 static char *shm_casefold_share_name(const char *name, size_t len)
 {
-	char *nfdi_name, *nfdicf_name;
+	g_autofree char *nfdi_name = NULL;
 
 	nfdi_name = g_utf8_normalize(name, len, G_NORMALIZE_NFD);
 	if (!nfdi_name)
-		goto out_ascii;
+		return g_ascii_strdown(name, len);
 
-	nfdicf_name = g_utf8_casefold(nfdi_name, strlen(nfdi_name));
-	g_free(nfdi_name);
-	return nfdicf_name;
-out_ascii:
-	g_free(nfdi_name);
-	return g_ascii_strdown(name, len);
+	return g_utf8_casefold(nfdi_name, strlen(nfdi_name));
 }
 
 guint shm_share_name_hash(gconstpointer name)
 {
-	char *cf_name;
-	guint hash;
-
-	cf_name = shm_casefold_share_name(name, strlen(name));
-	hash = g_str_hash(cf_name);
-	g_free(cf_name);
-	return hash;
+	g_autofree char *cf_name = shm_casefold_share_name(name, strlen(name));
+	return g_str_hash(cf_name);
 }
 
 gboolean shm_share_name_equal(gconstpointer lname, gconstpointer rname)
 {
-	char *cf_lname, *cf_rname;
-	gboolean equal;
-
-	cf_lname = shm_casefold_share_name(lname, strlen(lname));
-	cf_rname = shm_casefold_share_name(rname, strlen(rname));
-	equal = g_str_equal(cf_lname, cf_rname);
-	g_free(cf_lname);
-	g_free(cf_rname);
-	return equal;
+	g_autofree char *cf_lname = shm_casefold_share_name(lname, strlen(lname));
+	g_autofree char *cf_rname = shm_casefold_share_name(rname, strlen(rname));
+	return g_str_equal(cf_lname, cf_rname);
 }
 
 int shm_init(void)


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

No idea if this is even desired. It sort of requires goto removals. It also doesn't work in loops. clang-analyzer also seems to get confused.

I think @atheik will want gchar removals. There's more opportunity to do this elsewhere.