### PR TITLE
ksmbd-tools: fix worker_init_sa_handler return type

### DIFF
--- a/mountd/mountd.c
+++ b/mountd/mountd.c
@@ -97,7 +97,7 @@ static void worker_sa_sigaction(int signo, siginfo_t *siginfo, void *ucontext)
 	_Exit(128 + signo);
 }
 
-static int worker_init_sa_handler(sigset_t sigset)
+static void worker_init_sa_handler(sigset_t sigset)
 {
 	int signo;
 


### PR DESCRIPTION
The function doesn't return any errors, so switch it to void to silence compiler warnings such as:
  mountd.c: In function 'worker_init_sa_handler':
  mountd.c:114:1: error: no return statement in function returning
		  non-void [-Werror=return-type]
    114 | }
        | ^