### PR TITLE
ksmbd.service: remove network-online.target dependency

### DIFF
--- a/ksmbd.service.in
+++ b/ksmbd.service.in
@@ -1,8 +1,7 @@
 [Unit]
 Description=ksmbd userspace daemon
 Requires=modprobe@ksmbd.service
-Wants=network-online.target
-After=modprobe@ksmbd.service network.target network-online.target
+After=modprobe@ksmbd.service network.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
The network does not need to be fully online to start a daemon that listens on the wildcard address.

If the admin alters the default configuration to listen on specific interfaces or addresses, they can alter the systemd unit accordingly.