### PR TITLE
ksmbd-tools: fix race conditions and thread safety in user management

### DIFF
--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -373,13 +373,13 @@ static void __handle_login_request(struct ksmbd_login_response *resp,
 {
 	int hash_sz;
 
+	g_rw_lock_reader_lock(&user->update_lock);
 	resp->gid = user->gid;
 	resp->uid = user->uid;
-	resp->status = user->flags;
-	resp->status |= KSMBD_USER_FLAG_OK;
-
+	resp->status = user->flags | KSMBD_USER_FLAG_OK;
 	if (user->ngroups)
 		resp->status |= KSMBD_USER_FLAG_EXTENSION;
+	g_rw_lock_reader_unlock(&user->update_lock);
 
 	hash_sz = usm_copy_user_passhash(user,
 					 resp->hash,

--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -456,6 +456,7 @@ int usm_handle_logout_request(struct ksmbd_logout_request *req)
 	if (!user)
 		return -ENOENT;
 
+	g_rw_lock_writer_lock(&user->update_lock);
 	if (req->account_flags & KSMBD_USER_FLAG_BAD_PASSWORD) {
 		if (user->failed_login_count < 10)
 			user->failed_login_count++;
@@ -465,6 +466,7 @@ int usm_handle_logout_request(struct ksmbd_logout_request *req)
 		user->failed_login_count = 0;
 		user->flags &= ~KSMBD_USER_FLAG_DELAY_SESSION;
 	}
+	g_rw_lock_writer_unlock(&user->update_lock);
 
 	put_ksmbd_user(user);
 	return 0;

--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -294,7 +294,9 @@ int usm_add_guest_account(char *name)
 	if (!user) {
 		ret = -EINVAL;
 	} else {
+		g_rw_lock_writer_lock(&user->update_lock);
 		set_user_flag(user, KSMBD_USER_FLAG_GUEST_ACCOUNT);
+		g_rw_lock_writer_unlock(&user->update_lock);
 		put_ksmbd_user(user);
 	}
 	return ret;


### PR DESCRIPTION
This patch series addresses several race conditions and thread safety issues discovered in the user management subsystem `tools/management/user.c` of ksmbd-tools.

Since the `ksmbd_user` object can be accessed concurrently by multiple threads processing simultaneous login/logout requests or administrative actions, it is crucial that all modifications and reads of shared fields (such as flags, failed_login_count, and ref_count) are properly synchronized using the object's update_lock.

The series resolves these thread safety issues.
- ksmbd-tools: Fix potential data race in __handle_login_request()
- ksmbd-tools: Fix potential data race in usm_add_guest_account()
- ksmbd-tools: Fix potential data race in usm_handle_logout_request()

Signed-off-by: Yunseong Kim <yunseong.kim@est.tech>