### PR TITLE
user: fix memory leak when sgid allocation fails in new_ksmbd_user

### DIFF
--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -132,6 +132,7 @@ static struct ksmbd_user *new_ksmbd_user(char *name, char *pwd)
 		g_free(sgid);
 		sgid = g_try_malloc0(sizeof(gid_t) * ngroups);
 		if (!sgid) {
+			g_free(user->pass);
 			g_free(user);
 			return NULL;
 		}


### PR DESCRIPTION
When g_try_malloc0 for the supplementary groups array fails, user->pass (allocated by base64_decode) was not freed before freeing the user structure, leaking the memory.